### PR TITLE
add capistrano deploy

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,39 @@
+# Load DSL and set up stages
+require "capistrano/setup"
+
+# Include default deployment tasks
+require "capistrano/deploy"
+
+# Load the SCM plugin appropriate to your project:
+#
+# require "capistrano/scm/hg"
+# install_plugin Capistrano::SCM::Hg
+# or
+# require "capistrano/scm/svn"
+# install_plugin Capistrano::SCM::Svn
+# or
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
+# Include tasks from other gems included in your Gemfile
+#
+# For documentation on these, see for example:
+#
+#   https://github.com/capistrano/rvm
+#   https://github.com/capistrano/rbenv
+#   https://github.com/capistrano/chruby
+#   https://github.com/capistrano/bundler
+#   https://github.com/capistrano/rails
+#   https://github.com/capistrano/passenger
+#
+# require "capistrano/rvm"
+# require "capistrano/rbenv"
+# require "capistrano/chruby"
+require "capistrano/bundler"
+# require "capistrano/rails/assets"
+# require "capistrano/rails/migrations"
+# require "capistrano/passenger"
+require 'dlss/capistrano'
+
+# Load custom tasks from `lib/capistrano/tasks` if you have any defined
+Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Capfile
+++ b/Capfile
@@ -33,7 +33,10 @@ require "capistrano/bundler"
 # require "capistrano/rails/assets"
 # require "capistrano/rails/migrations"
 # require "capistrano/passenger"
+
 require 'dlss/capistrano'
+# require 'capistrano/honeybadger'
+# require 'whenever/capistrano'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem 'coveralls', require: false
 end
 
-# group :deployment do
-#   gem 'dlss-capistrano'
-# end
+group :deployment do
+  gem 'capistrano-bundler'
+  gem 'dlss-capistrano'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    airbrussh (1.3.0)
+      sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.0)
     blue-daemons (1.1.11)
     bluepill (0.1.3)
@@ -30,7 +32,24 @@ GEM
       blue-daemons (~> 1.1)
       state_machine (~> 1.1)
     builder (3.2.3)
-    byebug (10.0.0)
+    bundler-audit (0.6.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
+    byebug (10.0.1)
+    capistrano (3.10.1)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    capistrano-bundle_audit (0.2.1)
+      bundler-audit (~> 0.5)
+      capistrano (~> 3.0)
+    capistrano-bundler (1.3.0)
+      capistrano (~> 3.1)
+      sshkit (~> 1.2)
+    capistrano-one_time_key (0.0.1)
+      capistrano (~> 3.0)
+    capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -46,6 +65,11 @@ GEM
     deprecation (0.99.0)
       activesupport
     diff-lcs (1.3)
+    dlss-capistrano (3.4.1)
+      capistrano (~> 3.0)
+      capistrano-bundle_audit (>= 0.1.0)
+      capistrano-one_time_key
+      capistrano-shared_configs
     docile (1.1.5)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
@@ -128,6 +152,8 @@ GEM
     mustermann (1.0.2)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
@@ -146,7 +172,7 @@ GEM
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
     parallel (1.12.1)
-    parser (2.5.0.3)
+    parser (2.5.0.4)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     pry (0.11.3)
@@ -159,7 +185,7 @@ GEM
     rack-protection (2.0.1)
       rack
     rainbow (3.0.0)
-    rake (12.3.0)
+    rake (12.3.1)
     rdf (1.99.1)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (1.99.0)
@@ -251,6 +277,9 @@ GEM
       nokogiri
       stomp
       xml-simple
+    sshkit (1.16.0)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     stanford-mods (2.5.1)
       activesupport
       mods (~> 2.2)
@@ -283,7 +312,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  capistrano-bundler
   coveralls
+  dlss-capistrano
   dor-services (~> 5.28)
   lyber-core
   moab-versioning

--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ end
 
 begin
   require 'rubocop/rake_task'
+  desc 'Run rubocop'
   RuboCop::RakeTask.new
 rescue LoadError
   desc 'Run rubocop'

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -18,7 +18,7 @@ ROBOT_LOG.level = Logger::SEV_LABEL.index(ENV['ROBOT_LOG_LEVEL']) || Logger::INF
 # end
 
 # Load core robot services
-require 'dor-services'
+require 'dor-services' # FIXME: do we really need dor-services?   Just for Dor::Config ??
 require 'lyber_core'
 LyberCore::Log.set_level(ROBOT_LOG.level)
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ set :repo_url, 'https://github.com/sul-dlss/preservation_robots.git'
 ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 
 # Default deploy_to directory is /var/www/my_app_name
-set :deploy_to, "/opt/app/account/#{fetch(:application)}"
+set :deploy_to, "/opt/app/pres/#{fetch(:application)}"
 
 # Default value for :format is :airbrussh.
 # set :format, :airbrussh
@@ -23,7 +23,7 @@ set :deploy_to, "/opt/app/account/#{fetch(:application)}"
 
 # Default value for linked_dirs is []
 # append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
-append :linked_dirs, %w[log run config/environments config/certs tmp]
+append :linked_dirs, "log", "run", "config/environments", "config/certs", "tmp"
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -41,8 +41,6 @@ set :bundle_without, %w[development deployment test].join(' ')
 
 set :stages, %w[stage prod]
 
-set :default_env, robot_environment: fetch(:deploy_environment)
-
 # set :honeybadger_env, fetch(:deployment)
 # set :whenever_environment, fetch(:deploy_environment)
 # set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,73 @@
+set :application, 'preservation_robots'
+set :repo_url, 'https://github.com/sul-dlss/preservation_robots.git'
+
+# Default branch is :master
+ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
+
+# Default deploy_to directory is /var/www/my_app_name
+set :deploy_to, "/opt/app/account/#{fetch(:application)}"
+
+# Default value for :format is :airbrussh.
+# set :format, :airbrussh
+
+# You can configure the Airbrussh format using :format_options.
+# These are the defaults.
+# set :format_options, command_output: true, log_file: "log/capistrano.log", color: :auto, truncate: :auto
+
+# Default value for :pty is false
+# set :pty, true
+
+# Default value for :linked_files is []
+# append :linked_files, "config/database.yml", "config/secrets.yml"
+# append :linked_files, %w(config/honeybadger.yml)
+
+# Default value for linked_dirs is []
+# append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
+append :linked_dirs, %w[log run config/environments config/certs tmp]
+
+# Default value for default_env is {}
+# set :default_env, { path: "/opt/ruby/bin:$PATH" }
+
+# Default value for local_user is ENV['USER']
+# set :local_user, -> { `git config user.name`.chomp }
+
+# Default value for keep_releases is 5
+# set :keep_releases, 5
+
+# Uncomment the following to require manually verifying the host key before first deploy.
+# set :ssh_options, verify_host_key: :secure
+
+set :bundle_without, %w[development deployment test].join(' ')
+
+set :stages, %w[stage prod]
+
+set :default_env, robot_environment: fetch(:deploy_environment)
+
+# set :honeybadger_env, fetch(:deployment)
+# set :whenever_environment, fetch(:deploy_environment)
+# set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
+
+namespace :deploy do
+  desc 'Restart application'
+  task :restart do
+    on roles(:app), in: :sequence, wait: 10 do
+      within release_path do
+        # Uncomment  with the first deploy
+        # execute :bundle, :install
+
+        # Comment with the first deploy
+        test :bundle, :exec, :controller, :stop
+        sleep 10 # wait for clean stop
+        test :bundle, :exec, :controller, :quit
+
+        # Always call the boot
+        execute :bundle, :exec, :controller, :boot
+      end
+    end
+  end
+
+  # update shared_configs before restarting app
+  before :restart, 'shared_configs:update'
+
+  after :publishing, :restart
+end

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,0 +1,5 @@
+server 'pres-robots1-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
+
+Capistrano::OneTimeKey.generate_one_time_key!
+
+set :deploy_environment, 'production'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,5 +1,6 @@
-server 'pres-robots1-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
+server 'preservation-robots1-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 
-set :deploy_environment, 'production'
+set :deploy_environment, 'prod'
+set :default_env, robot_environment: fetch(:deploy_environment)

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,0 +1,5 @@
+server 'pres-robots1-stage.stanford.edu', user: 'pres', roles: %w[web app db]
+
+Capistrano::OneTimeKey.generate_one_time_key!
+
+set :deploy_environment, 'test'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,5 +1,6 @@
-server 'pres-robots1-stage.stanford.edu', user: 'pres', roles: %w[web app db]
+server 'preservation-robots1-stage.stanford.edu', user: 'pres', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'test'
+set :default_env, robot_environment: fetch(:deploy_environment)

--- a/config/environments/robots_example.yml
+++ b/config/environments/robots_example.yml
@@ -1,0 +1,48 @@
+#
+#  Robot allocation strategy
+#
+#  Format:
+#
+#    host:
+#      - robot[:lane[:instances]]
+#
+#  where
+#    1. robot is a single robot identifier (fully-qualified with
+#       REPO_SUITE_ROBOT, e.g., "sdr_sdrIngestWF_technical-metadata").
+#    2. lane is
+#          - a single identifier ('A'), or
+#          - a list of identiers ('A,B,C'), or
+#          - an asterix (*).
+#    3. instances is a single integer.
+#
+#  Both lane and instances are optional. Lane defaults to 'default', and
+#  instances defaults to 1.
+#
+#  When a robot is allocated to multiple lanes, it reads them in
+#  PRIORITY ORDER. That is, if a robot is listening to lanes A, B, and C,
+#  it works on lane A until empty, then lane B until empty, and then
+#  lane C until empty. In the meantime, if a job comes in on a 'faster'
+#  lane, it works on that after finishing it's current job (i.e., after
+#  working on a job in lane C, if a job comes in on lane A in the intermin,
+#  the robot will work on the lane A job next before returning to lane C).
+#  When using an asterix for the lane designator, the lanes are processed
+#  in alphabetical order.
+#
+#  Note that the syntax is YAML, so the lists must not contain spaces or
+#  needs to be quoted.
+#
+#    RIGHT
+#      - sdr_preservationIngestWF_transfer-object:A:5
+#      - 'sdr_spreservationIngestWF_transfer-object : A : 5'
+#
+#    WRONG
+#      - sdr_preservationIngestWF_transfer-object : A : 5
+#      - sdr_preservationIngestWF_transfer-object: A: 5
+#
+sul-robots-host-example:
+  - sdr_preservationIngestWF_transfer-object
+  - sdr_preservationIngestWF_validate-bag
+  - sdr_preservationIngestWF_verify-apo
+  - sdr_preservationIngestWF_update-moab
+  - sdr_preservationIngestWF_update-catalog
+  - sdr_preservationIngestWF_complete-ingest

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,8 +24,8 @@ Dor::Config.configure do
   end
 
   transfer_object do
-    dor_host "userid@dor-host"
-    input_dir "/dor/export/"
+    from_host "userid@from-host"
+    from_dir "/dor/export/"
   end
 end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,7 @@
 cert_dir = File.join(File.dirname(__FILE__), '..', 'certs')
 
 Dor::Config.configure do
+  # FIXME do we need ssl and certs?
   ssl do
     cert_file File.join(cert_dir, '.crt')
     key_file File.join(cert_dir, '.key')
@@ -29,5 +30,8 @@ Dor::Config.configure do
   end
 end
 
-#REDIS_URL = ''
 REDIS_URL = 'localhost:6379/resque:test'
+
+# kurma-stage has the following (probably to use dor_workflow_service)
+# WORKFLOW_URI = 'https://workflows.example.org'
+# Dor::WorkflowService.configure(WORKFLOW_URI + '/')

--- a/config/robots.yml
+++ b/config/robots.yml
@@ -1,0 +1,11 @@
+#
+# robots.yml - Provides the complete list of all robots in this suite
+#   to support robot-controller verify command, see
+#   https://github.com/sul-dlss/robot-controller/blob/master/bin/controller#L61-L62
+#
+- sdr_preservationIngestWF_transfer-object
+- sdr_preservationIngestWF_validate-bag
+- sdr_preservationIngestWF_verify-apo
+- sdr_preservationIngestWF_update-moab
+- sdr_preservationIngestWF_update-catalog
+- sdr_preservationIngestWF_complete-ingest

--- a/robots/preservation/transfer_object.rb
+++ b/robots/preservation/transfer_object.rb
@@ -47,8 +47,8 @@ module Preservation
     VERSION_METADATA_PATH_SUFFIX = '/data/metadata/versionMetadata.xml'.freeze
 
     def verify_version_metadata
-      vm_path = File.join(Dor::Config.transfer_object.input_dir, bare_druid, VERSION_METADATA_PATH_SUFFIX)
-      cmd = "if ssh #{Dor::Config.transfer_object.dor_host} test -e #{vm_path}; then echo yes; else echo no; fi"
+      vm_path = File.join(Dor::Config.transfer_object.from_dir, bare_druid, VERSION_METADATA_PATH_SUFFIX)
+      cmd = "if ssh #{Dor::Config.transfer_object.from_host} test -e #{vm_path}; then echo yes; else echo no; fi"
       raise(ItemError, "#{vm_path} not found") if self.class.execute_shell_command(cmd) == 'no'
     end
 
@@ -75,8 +75,8 @@ module Preservation
     # ssh user@remotehost "tar -cf - srcdir | tar -C destdir -xf -
     # Note that symbolic links from /dor/export to /dor/workspace get translated into real files by use of --dereference
     def tarpipe_command(deposit_dir)
-      "ssh #{Dor::Config.transfer_object.dor_host} " \
-        '"tar -C ' + "#{Dor::Config.transfer_object.input_dir} --dereference -cf - #{bare_druid}" + ' "' \
+      "ssh #{Dor::Config.transfer_object.host} " \
+        '"tar -C ' + "#{Dor::Config.transfer_object.from_dir} --dereference -cf - #{bare_druid}" + ' "' \
         " | tar -C #{deposit_dir} -xf -"
     end
 

--- a/robots/preservation/transfer_object.rb
+++ b/robots/preservation/transfer_object.rb
@@ -75,7 +75,7 @@ module Preservation
     # ssh user@remotehost "tar -cf - srcdir | tar -C destdir -xf -
     # Note that symbolic links from /dor/export to /dor/workspace get translated into real files by use of --dereference
     def tarpipe_command(deposit_dir)
-      "ssh #{Dor::Config.transfer_object.host} " \
+      "ssh #{Dor::Config.transfer_object.from_host} " \
         '"tar -C ' + "#{Dor::Config.transfer_object.from_dir} --dereference -cf - #{bare_druid}" + ' "' \
         " | tar -C #{deposit_dir} -xf -"
     end

--- a/spec/preservation/transfer_object_spec.rb
+++ b/spec/preservation/transfer_object_spec.rb
@@ -2,8 +2,8 @@ describe Preservation::TransferObject do
   let(:bare_druid) { 'jc837rq9922' }
   let(:druid) { "druid:#{bare_druid}" }
   let(:vm_file_path) do
-    input_dir = File.join(Dor::Config.transfer_object.input_dir, bare_druid)
-    File.join(input_dir, described_class::VERSION_METADATA_PATH_SUFFIX)
+    from_dir = File.join(Dor::Config.transfer_object.from_dir, bare_druid)
+    File.join(from_dir, described_class::VERSION_METADATA_PATH_SUFFIX)
   end
   let(:deposit_dir_pathname) { Pathname(File.join(File.dirname(__FILE__), '..', 'fixtures', 'deposit', 'foo')) }
   let(:deposit_bag_pathname) { Pathname(File.join(deposit_dir_pathname, bare_druid)) }
@@ -22,7 +22,7 @@ describe Preservation::TransferObject do
 
   it 'raises ItemError if versionMetadata.xml file for druid does not exist' do
     allow(xfer_obj).to receive(:verify_accesssion_wf_step_completed)
-    cmd_regex = Regexp.new(".*ssh #{Dor::Config.transfer_object.dor_host} test -e #{vm_file_path}.*")
+    cmd_regex = Regexp.new(".*ssh #{Dor::Config.transfer_object.from_host} test -e #{vm_file_path}.*")
     expect(Preservation::Base).to receive(:execute_shell_command).with(a_string_matching(cmd_regex)).and_return('no')
     exp_msg = "Error transferring object: #{vm_file_path} not found"
     expect { xfer_obj.perform(druid) }.to raise_error(Preservation::ItemError, exp_msg)
@@ -86,7 +86,7 @@ describe Preservation::TransferObject do
     expect(Dor::WorkflowService).to receive(:get_workflow_status)
       .with('dor', druid, 'accessionWF', 'sdr-ingest-transfer').and_return('completed')
 
-    cmd_regex = Regexp.new("if ssh #{Dor::Config.transfer_object.dor_host} test -e #{vm_file_path}.*")
+    cmd_regex = Regexp.new("if ssh #{Dor::Config.transfer_object.from_host} test -e #{vm_file_path}.*")
     expect(Preservation::Base).to receive(:execute_shell_command).with(a_string_matching(cmd_regex)).and_return('yes')
 
     mock_moab = instance_double(Moab::StorageObject)


### PR DESCRIPTION
Aside from adding capistrano, there is a bit of cleanup/refactoring mixed in:

- add desc to rubocop rake task so it shows up with rake -T
- boot.rb got a comment about dor-services gem
- config/robots.yml file added to support robot-controller's verify command
- tweaked the config var names for transfer-object (matches shared-configs)

Closes #22