### PR TITLE
Use base class methods

### DIFF
--- a/robots/preservation_ingest/transfer_object.rb
+++ b/robots/preservation_ingest/transfer_object.rb
@@ -13,7 +13,7 @@ module Robots
         end
 
         def perform(druid)
-          @druid = druid
+          @druid = druid # for base class attr_accessor
           transfer_object
         end
 

--- a/robots/preservation_ingest/update_moab.rb
+++ b/robots/preservation_ingest/update_moab.rb
@@ -14,15 +14,13 @@ module Robots
 
         def perform(druid)
           LyberCore::Log.debug("#{ROBOT_NAME} #{druid} starting")
-          storage_object = Moab::StorageServices.find_storage_object(druid, true)
-          storage_object.object_pathname.mkpath
-          update_moab(storage_object)
+          update_moab
         end
 
         private
 
-        def update_moab(storage_object)
-          new_version = storage_object.ingest_bag
+        def update_moab
+          new_version = moab_object.ingest_bag
           result = new_version.verify_version_storage
           return if result.verified
           LyberCore::Log.info result.to_json(false)

--- a/robots/preservation_ingest/update_moab.rb
+++ b/robots/preservation_ingest/update_moab.rb
@@ -13,13 +13,14 @@ module Robots
         end
 
         def perform(druid)
-          LyberCore::Log.debug("#{ROBOT_NAME} #{druid} starting")
+          @druid = druid # for base class attr_accessor
           update_moab
         end
 
         private
 
         def update_moab
+          LyberCore::Log.debug("#{ROBOT_NAME} #{druid} starting")
           new_version = moab_object.ingest_bag
           result = new_version.verify_version_storage
           return if result.verified

--- a/robots/preservation_ingest/update_moab.rb
+++ b/robots/preservation_ingest/update_moab.rb
@@ -4,7 +4,7 @@ module Robots
   module SdrRepo
     # The workflow package name - match the actual workflow name, minus ending WF (using CamelCase)
     module PreservationIngest
-      # Robot for validating bag in the Moab object deposit area
+      # Robot for ingesting deposit bag into Moab object (creating a new version)
       class UpdateMoab < Base
         ROBOT_NAME = 'update-moab'.freeze
 

--- a/robots/preservation_ingest/validate_bag.rb
+++ b/robots/preservation_ingest/validate_bag.rb
@@ -15,7 +15,7 @@ module Robots
         attr_reader :druid
 
         def perform(druid)
-          @druid = druid
+          @druid = druid # for base class attr_accessor
           validate_bag
         end
 

--- a/robots/preservation_ingest/validate_bag.rb
+++ b/robots/preservation_ingest/validate_bag.rb
@@ -23,7 +23,6 @@ module Robots
 
         def validate_bag
           LyberCore::Log.debug("#{ROBOT_NAME} #{druid} starting")
-          moab_object = Stanford::StorageServices.find_storage_object(druid, true)
           deposit_bag_validator = Moab::DepositBagValidator.new(moab_object)
           validation_errors = deposit_bag_validator.validation_errors
           raise(ItemError, "Bag validation failure(s): #{validation_errors}") if validation_errors.any?

--- a/robots/preservation_ingest/verify_apo.rb
+++ b/robots/preservation_ingest/verify_apo.rb
@@ -19,7 +19,7 @@ module Robots
         end
 
         def perform(druid)
-          @druid = druid
+          @druid = druid # for base class attr_accessor
           verify_governing_apo
         end
 

--- a/spec/preservation_ingest/update_moab_spec.rb
+++ b/spec/preservation_ingest/update_moab_spec.rb
@@ -14,7 +14,6 @@ describe Robots::SdrRepo::PreservationIngest::UpdateMoab do
 
     it 'calls #ingest_bag and verify_version_storage on Moab::StorageObjectVersion' do
       allow(LyberCore::Log).to receive(:debug).with("update-moab druid:bj102hs9687 starting")
-      expect(Moab::StorageServices).to receive(:find_storage_object).with(full_druid, true).and_return(mock_so)
       expect(mock_path).to receive(:mkpath)
       expect(mock_so).to receive(:ingest_bag).and_return(mock_new_version)
       allow(verification_result).to receive(:verified).and_return(true)

--- a/spec/preservation_ingest/update_moab_spec.rb
+++ b/spec/preservation_ingest/update_moab_spec.rb
@@ -9,12 +9,10 @@ describe Robots::SdrRepo::PreservationIngest::UpdateMoab do
   context '#perform' do
     before do
       allow(Moab::StorageServices).to receive(:find_storage_object).and_return(mock_so)
-      allow(mock_path).to receive(:mkpath)
     end
 
     it 'calls #ingest_bag and verify_version_storage on Moab::StorageObjectVersion' do
       allow(LyberCore::Log).to receive(:debug).with("update-moab druid:bj102hs9687 starting")
-      expect(mock_path).to receive(:mkpath)
       expect(mock_so).to receive(:ingest_bag).and_return(mock_new_version)
       allow(verification_result).to receive(:verified).and_return(true)
       expect(mock_new_version).to receive(:verify_version_storage).and_return(verification_result)


### PR DESCRIPTION
A couple of robots weren't taking advantage of the base class methods (probably because they were written before those methods existed).  This fixes that, and tweaks the update_moab robot a bit, as mkpath should be done by .ingest_bag call.

