### PR TITLE
update settings.yml and boot.rb to include missing configurations

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -41,13 +41,14 @@ Dor::WorkflowService.configure(
   dor_services_url: Settings.workflow.dor_services_url
 )
 
+require 'robots'
+require 'robot-controller'
+
 require 'moab'
+require 'moab/stanford'
 Moab::Config.configure do
   storage_roots Settings.moab.storage_roots
   storage_trunk Settings.moab.storage_trunk
   deposit_trunk Settings.moab.deposit_trunk
   path_method Settings.moab.path_method
 end
-
-require 'robots'
-require 'robot-controller'

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -34,9 +34,10 @@ else
 end
 
 require 'dor-workflow-service'
+wf_log = Logger.new(Settings.workflow.logfile, Settings.workflow.shift_age)
 Dor::WorkflowService.configure(
   Settings.workflow.url,
-  logger: LyberCore::Log.class_variable_get(:@@log), # reuse a logger
+  logger: wf_log,
   timeout: Settings.workflow.timeout || 0,
   dor_services_url: Settings.workflow.dor_services_url
 )

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,6 @@ set :deploy_to, "/opt/app/pres/#{fetch(:application)}"
 # Default value for linked_dirs is []
 # append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
 append :linked_dirs, 'log', 'run', 'config/environments', 'config/certs', 'tmp'
-append :linked_files, 'log/wfs/workflow_service.log'
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,9 +8,8 @@ lybercore_log: 'log/lybercore.log'
 workflow:
   url: 'https://workflows.example.org'
   dor_services_url: 'https://fakeuser:fakepass@fakeserver.example.edu/dor'
-  # FIXME: if we get workflows logging to the individual robot logs, remove the following comments
-  # logfile: 'log/wfs/workflow_service.log'
-  # shift_age: 'weekly'
+  logfile: 'log/workflow_service.log'
+  shift_age: 'weekly'
   timeout: 60 # seconds
 
 # where to find the deposit bag to be preserved

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,13 +1,33 @@
-dor_services:
-  url: 'https://fakeuser:fakepass@fakeserver.example.edu/dor'
+redis:
+  url: 'localhost:6379/resque:test'
+  timeout: 10 # seconds
+
+lybercore_log: 'log/lybercore.log'
+
+# for workflows
 workflow:
   url: 'https://workflows.example.org'
+  dor_services_url: 'https://fakeuser:fakepass@fakeserver.example.edu/dor'
+  # FIXME: if we get workflows logging to the individual robot logs, remove the following comments
   # logfile: 'log/wfs/workflow_service.log'
   # shift_age: 'weekly'
   timeout: 60 # seconds
+
 # where to find the deposit bag to be preserved
 transfer_object:
   from_host: 'userid@common-accessioning-vm'
   from_dir: '/dor/export/'
-redis:
-  url: 'localhost:6379/resque:test'
+
+ssl:
+  # NOTE:  could use cert and key in /etc/pki/tls dir ... w some puppet fun?
+  cert_file: 'dir/with/cert/files/common-accesioning-vm.crt'
+  key_file: 'dir/with/cert/files/common-accesioning-vm.key'
+  key_pass: 'keypass'
+
+moab:
+  # storage_roots:
+  #   - '/services-disk/store1'
+  #   - '/services-disk/store2'
+  storage_trunk: 'sdr2objects'
+  deposit_trunk: 'deposit'
+  path_method: 'druid_tree'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,3 @@ end
 
 bootfile = File.join(File.dirname(__FILE__), '..', 'config/boot')
 require bootfile
-
-require 'moab'
-require 'moab/stanford'


### PR DESCRIPTION
Adds settings and boot.rb code so robots are again as functional with dor-workflow-service gem as they were with dor-services gem.

In other words, this is the follow-on work from #45, which migrated us from using dor-services to using dor-workflow-service and yml configs instead of ruby ones. 

Closes #49