### PR TITLE
Rewrite sdr-preservation-core weekly-stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp/*.*
 .pry_history
 
 config/environments/development.rb
+config/certs

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,7 @@ RSpec/ExampleLength:
   Max: 10
   Exclude:
     - spec/preservation_ingest/transfer_object_spec.rb # lots of expectations to set up for some specs
+    - spec/lib/stats_reporter_spec.rb # mimicking cli output takes many lines
 
 RSpec/FilePath:
   Enabled: false # paths become long to no gain

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,12 @@ gem 'rake'
 gem 'pry' # useful for production environment
 
 # Stanford DLSS gems
-gem 'dor-workflow-service', '~> 2.2'
+gem 'dor-workflow-service', '>= 2.3' # need 2.3 or higher for get_output_for_step calls
 gem 'moab-versioning', '>= 4.2.0' # work with Moab Objects; 4.2.0 has DepositBagValidator
 gem 'lyber-core' # robot code
 gem 'robot-controller' # robot code
 gem 'honeybadger' # for error reporting / tracking / notifications
+gem 'text-table' # to generate tables for StatsReporter
 gem 'whenever' # manage cron for robots and monitoring
 
 group :development, :test do
@@ -21,6 +22,7 @@ end
 group :test do
   gem 'rspec'
   gem 'coveralls', require: false
+  gem 'webmock'
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.0)
@@ -48,6 +50,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     deep_merge (1.2.1)
     diff-lcs (1.3)
     dlss-capistrano (3.4.1)
@@ -56,7 +60,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.1.5)
-    dor-workflow-service (2.2.1)
+    dor-workflow-service (2.3.0)
       activesupport (>= 3.2.1, < 6)
       confstruct (>= 0.2.7, < 2)
       faraday (~> 0.9, >= 0.9.2)
@@ -93,6 +97,7 @@ GEM
       dry-types (~> 0.12.0)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
+    hashdiff (0.3.7)
     hashie (3.5.7)
     honeybadger (3.3.0)
     i18n (1.0.0)
@@ -134,6 +139,7 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
+    public_suffix (3.0.2)
     rack (2.0.4)
     rack-protection (2.0.1)
       rack
@@ -177,6 +183,7 @@ GEM
     rubocop-rspec (1.23.0)
       rubocop (>= 0.52.1)
     ruby-progressbar (1.9.0)
+    safe_yaml (1.0.4)
     simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -193,6 +200,7 @@ GEM
     state_machine (1.2.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
+    text-table (1.2.4)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -202,6 +210,10 @@ GEM
     unicode-display_width (1.3.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
+    webmock (3.3.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     whenever (0.9.7)
       chronic (>= 0.6.3)
 
@@ -213,7 +225,7 @@ DEPENDENCIES
   config
   coveralls
   dlss-capistrano
-  dor-workflow-service (~> 2.2)
+  dor-workflow-service (>= 2.3)
   honeybadger
   lyber-core
   moab-versioning (>= 4.2.0)
@@ -224,6 +236,8 @@ DEPENDENCIES
   rspec
   rubocop (~> 0.52.1)
   rubocop-rspec (~> 1.23.0)
+  text-table
+  webmock
   whenever
 
 BUNDLED WITH

--- a/bin/stats_report.rb
+++ b/bin/stats_report.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.dirname(__FILE__) + '/../lib/stats_reporter')
+require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
+
+stats_reporter = StatsReporter.new
+puts "Stats compiled on #{Time.now.to_date}"
+puts "Storage stats for mounts on #{Socket.gethostname}:"
+puts stats_reporter.storage_report_text
+puts "Workflow stats:"
+puts stats_reporter.workflow_report_text

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,9 +19,9 @@ transfer_object:
 
 ssl:
   # NOTE:  could use cert and key in /etc/pki/tls dir ... w some puppet fun?
-  cert_file: 'dir/with/cert/files/common-accesioning-vm.crt'
-  key_file: 'dir/with/cert/files/common-accesioning-vm.key'
-  key_pass: 'keypass'
+  cert_file: 'config/certs/test.crt'
+  key_file: 'config/certs/test.key'
+  key_pass: ''
 
 moab:
   # storage_roots:

--- a/lib/stats_reporter.rb
+++ b/lib/stats_reporter.rb
@@ -1,0 +1,91 @@
+# generates text for a report on storage root size and object status
+class StatsReporter
+
+  require 'text-table'
+  require 'open3'
+
+  def storage_report_text
+    head = %w[filesystem total used pct_used free pct_free]
+    Text::Table.new(head: head, rows: storage_report_lines).to_s
+  end
+
+  def workflow_report_text
+    head = %w[workflow waiting error recent archived]
+    Text::Table.new(head: head, rows: workflow_report_lines).to_s
+  end
+
+  def df_output
+    stdout_str, _status = Open3.capture2('df -h')
+    stdout_str
+  end
+
+  def repository
+    workflow_xml.at_xpath('//workflow-def/@repository').value
+  end
+
+  def ingest_wf
+    workflow_xml.at_xpath('//workflow-def/@id').value
+  end
+
+  def ingest_wf_steps
+    workflow_xml.xpath('//process/@name').map(&:value)
+  end
+
+  private
+
+  def storage_mount_lines
+    df_output.split("\n").select { |line| line.include?('services-disk') }
+  end
+
+  def parsed_storage_mount_lines
+    storage_mount_lines.map do |line|
+      split_line = line.split
+      {
+        total: split_line[0], used: split_line[1],
+        remaining: split_line[2], percent_used: split_line[3],
+        filesystem: split_line[4], percent_free: "#{(100 - split_line[3].chop.to_i)}%"
+      }
+    end
+  end
+
+  def storage_report_lines
+    parsed_storage_mount_lines.map do |h|
+      [h.values_at(:filesystem, :total, :used, :percent_used, :remaining, :percent_free)]
+    end
+  end
+
+  def workflow_xml
+    @workflow_xml ||= File.open('config/workflows/sdr/preservationIngestWF') { |f| Nokogiri::XML(f) }
+  end
+
+  def waiting_count
+    Dor::WorkflowService.count_objects_in_step(ingest_wf, 'start-ingest',
+                                               'waiting', repository)
+  end
+
+  def erroring_count
+    ingest_wf_steps.map do |step|
+      Dor::WorkflowService.count_objects_in_step(ingest_wf, step,
+                                                 'error', repository)
+    end.sum
+  end
+
+  def completed_count
+    Dor::WorkflowService.count_objects_in_step(ingest_wf, 'complete-ingest',
+                                               'completed', repository)
+  end
+
+  def archived_count
+    Dor::WorkflowService.count_archived_for_workflow(ingest_wf, repository)
+  end
+
+  def workflow_report_lines
+    [[
+      ingest_wf,
+      waiting_count,
+      erroring_count,
+      completed_count,
+      archived_count
+    ]]
+  end
+end

--- a/spec/lib/stats_reporter_spec.rb
+++ b/spec/lib/stats_reporter_spec.rb
@@ -1,0 +1,88 @@
+require 'stats_reporter'
+describe StatsReporter do
+  let(:stats_reporter) { described_class.new }
+
+  describe '.df_output' do
+    it 'outputs stats on disk space' do
+      output = stats_reporter.df_output
+      # for example, this matches '5.0G  2.1G  2.6G  45% /'
+      size_regex = '[0-9]+(\.[0-9]+)?[A-Za-z]'
+      percent_regex = '[0-9]+\%'
+      regex = %r{#{size_regex}.+#{size_regex}.+#{size_regex}.+#{percent_regex}.*\s\/}
+      expect(output).to match(regex)
+    end
+  end
+
+  describe '.storage_report_text' do
+    it 'constructs a table from the linux df command output' do
+      df_shell_output = <<-SHELL
+      Filesystem            Size  Used Avail Use% Mounted on
+      /dev/mapper/rootvg-slash
+                            5.0G  2.1G  2.6G  45% /
+      tmpfs                 2.4G     0  2.4G   0% /dev/shm
+      /dev/sda1             490M   64M  401M  14% /boot
+      /dev/mapper/rootvg-app
+                            5.0G  338M  4.4G   8% /opt/app
+      /dev/mapper/rootvg-tmp
+                            2.0G   68M  1.9G   4% /tmp
+      /dev/mapper/rootvg-afscache
+                           1008M   37M  921M   4% /usr/vice/cache
+      /dev/mapper/rootvg-var
+                            5.0G  3.0G  1.8G  64% /var
+      AFS                   8.6G     0  8.6G   0% /afs
+      sf5-restrict-dev:/sdr_services_test_01
+                            2.0T  458G  1.6T  23% /services-disk
+
+      SHELL
+
+      table_output = <<-TABLE.strip_heredoc
+  +----------------+-------+------+----------+------+----------+
+  |   filesystem   | total | used | pct_used | free | pct_free |
+  +----------------+-------+------+----------+------+----------+
+  | /services-disk | 2.0T  | 458G | 23%      | 1.6T | 77%      |
+  +----------------+-------+------+----------+------+----------+
+      TABLE
+      allow(stats_reporter).to receive(:df_output).and_return(df_shell_output)
+      expect(stats_reporter.storage_report_text).to eq table_output
+    end
+  end
+
+  describe '#workflow_report_text' do
+    it 'constructs a table from several queries to the workflow service' do
+      # this is a little lazy: the error count below
+      # demonstrates requests for all workflow steps
+      # because 7 steps * 5 objects per step = 35
+      stub_request(:get, /workflow/)
+        .to_return(status: 200, body: "<objects count='5'>")
+      stats_reporter = described_class.new
+      table_output = <<-TABLE.strip_heredoc
+  +----------------------+---------+-------+--------+----------+
+  |       workflow       | waiting | error | recent | archived |
+  +----------------------+---------+-------+--------+----------+
+  | preservationIngestWF | 5       | 35    | 5      | 5        |
+  +----------------------+---------+-------+--------+----------+
+      TABLE
+      expect(stats_reporter.workflow_report_text).to eq(table_output)
+    end
+  end
+
+  describe '.repository' do
+    it 'returns the repository attribute value in the preservationIngestWF xml' do
+      expect(stats_reporter.repository).to eq('sdr')
+    end
+  end
+
+  describe '.ingest_wf' do
+    it 'returns the workflow definition id from the preservationIngestWF xml' do
+      expect(stats_reporter.ingest_wf).to eq('preservationIngestWF')
+    end
+  end
+
+  describe '.ingest_wf_steps' do
+    it 'returns an array of process names from the preservationIngestWF xml' do
+      expect(stats_reporter.ingest_wf_steps).to eq(["start-ingest", "transfer-object",
+                                                    "validate-bag", "verify-apo", "update-moab",
+                                                    "update-catalog", "complete-ingest"])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # Make sure specs run with the definitions from test.rb
 ENV['ROBOT_ENVIRONMENT'] = 'test'
 
+require 'webmock/rspec'
 require 'simplecov'
 require 'coveralls'
 Coveralls.wear!


### PR DESCRIPTION
Paired with @jmartin-sul on specs

- add certs dir to gitignore, and modify settings to make querying workflow from your laptop easier
- add some gem dependencies, for reasons commented in `Gemfile`
- add bin script to generate the report (punting on a whenever task to send it out to the right folks)
- add `stats_reporter` class to generate text for the bin script
- add tests for formerly untested code!

One concern is that because the workflow and steps have changed, I'm not 100% certain that the `waiting_count` and `completed_count` methods will return what we want, but I commented as such, and took my best guess.

Fixes #24 