### PR TITLE
Update catalog

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,12 +58,14 @@ Metrics/LineLength:
     - config/schedule.rb # one long cli command
     - spec/preservation_ingest/complete_ingest_spec.rb
     - spec/preservation_ingest/transfer_object_spec.rb # some long lines with fully namespaced classes
+    - spec/preservation_ingest/update_catalog_spec.rb # one long line #12
     - spec/preservation_ingest/update_moab_spec.rb # one long ling with fully namespaced classes
     - spec/preservation_ingest/validate_bag_spec.rb # one long line with fully namespaced classes
     - spec/preservation_ingest/verify_apo_spec.rb # one long line with fully namespaced classes
 Metrics/MethodLength:
   Exclude:
     - robots/preservation_ingest/base.rb # execute_shell_command
+    - robots/preservation_ingest/update_catalog.rb # one too many line [11/10]
 
 # --- Naming ---
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,8 @@ gem 'robot-controller' # robot code
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'text-table' # to generate tables for StatsReporter
 gem 'whenever' # manage cron for robots and monitoring
-gem 'faraday' # for ReST calls
+gem 'faraday' # for ReST calls to Preservation Catalog
+gem 'retries'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'robot-controller' # robot code
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'text-table' # to generate tables for StatsReporter
 gem 'whenever' # manage cron for robots and monitoring
+gem 'faraday' # for ReST calls
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,7 @@ DEPENDENCIES
   pry
   pry-byebug
   rake
+  retries
   robot-controller
   rspec
   rubocop (~> 0.52.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,7 @@ DEPENDENCIES
   coveralls
   dlss-capistrano
   dor-workflow-service (>= 2.3)
+  faraday
   honeybadger
   lyber-core
   moab-versioning (>= 4.2.0)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,3 +30,6 @@ moab:
   storage_trunk: 'sdr2objects'
   deposit_trunk: 'deposit'
   path_method: 'druid_tree'
+
+preservation_catalog:
+  url: 'http://localhost:3000'

--- a/robots/preservation_ingest/base.rb
+++ b/robots/preservation_ingest/base.rb
@@ -1,3 +1,4 @@
+require 'faraday'
 # Robot package to run under multiplexing infrastructure
 module Robots
   # Use DorRepo/SdrRepo to match the workflow repo (and avoid name collision with Dor module)

--- a/robots/preservation_ingest/base.rb
+++ b/robots/preservation_ingest/base.rb
@@ -1,4 +1,3 @@
-require 'faraday'
 # Robot package to run under multiplexing infrastructure
 module Robots
   # Use DorRepo/SdrRepo to match the workflow repo (and avoid name collision with Dor module)

--- a/robots/preservation_ingest/update_catalog.rb
+++ b/robots/preservation_ingest/update_catalog.rb
@@ -1,10 +1,14 @@
+require 'faraday'
+require 'retries'
+
 # Robot package to run under multiplexing infrastructure
 module Robots
   # Use DorRepo/SdrRepo to match the workflow repo (and avoid name collision with Dor module)
   module SdrRepo
     # The workflow package name - match the actual workflow name, minus ending WF (using CamelCase)
     module PreservationIngest
-      # what does this class do? FIXME
+      # sends ReST Create or Update Version request to PreservationCatalog, depending on whether this
+      # is a new Moab or an update to an existing Moab
       class UpdateCatalog < Base
         ROBOT_NAME = 'update-catalog'.freeze
 
@@ -20,18 +24,31 @@ module Robots
 
         private
 
-        def update_catalog
-          size = moab_object.size
-          storage_location = moab_object.storage_root
-          latest_version_id = moab_object.current_version_id
-          args = {
+        def http_args
+          {
             druid: druid,
-            incoming_version: latest_version_id,
-            incoming_size: size,
-            storage_location: storage_location
+            incoming_version: moab_object.current_version_id,
+            incoming_size: moab_object.size,
+            storage_location: moab_object.storage_root
           }
-          response = conn.post '/catalog', args
-          conn.patch "/catalog/#{druid}", args if response.status == 409
+        end
+
+        def handler
+          update_cat_msg = "Updating preservation catalog for #{druid}"
+          proc do |exception, attempt_number, _total_delay|
+            LyberCore::Log.warn("#{update_cat_msg}: try #{attempt_number} failed: #{exception.message}")
+            raise exception if attempt_number == 3
+          end
+        end
+
+        def update_catalog
+          with_retries(max_tries: 3, handler: handler, rescue: Faraday::Error) do
+            if moab_object.current_version_id == 1
+              conn.post '/catalog', http_args
+            else
+              conn.patch "/catalog/#{druid}", http_args
+            end
+          end
         end
 
         def conn

--- a/robots/preservation_ingest/update_catalog.rb
+++ b/robots/preservation_ingest/update_catalog.rb
@@ -21,7 +21,21 @@ module Robots
         private
 
         def update_catalog
-          # FIXME:  do something and update the comment too
+          size = moab_object.size
+          storage_location = moab_object.storage_root
+          latest_version_id = moab_object.current_version_id
+          args = {
+            druid: druid,
+            incoming_version: latest_version_id,
+            incoming_size: size,
+            storage_location: storage_location
+          }
+          response = conn.post '/catalog', args
+          conn.patch "/catalog/#{druid}", args if response.status == 409
+        end
+
+        def conn
+          @conn ||= Faraday.new(url: Settings.preservation_catalog.url)
         end
       end
     end

--- a/spec/preservation_ingest/update_catalog_spec.rb
+++ b/spec/preservation_ingest/update_catalog_spec.rb
@@ -1,0 +1,54 @@
+describe Robots::SdrRepo::PreservationIngest::UpdateCatalog do
+  subject(:update_catalog_obj) { described_class.new }
+
+  let(:bare_druid) { 'bj102hs9687' }
+  let(:size) { 2342 }
+  let(:version) { 3 }
+  let(:strg_root) { "some/storage/location/from/endpoint/table" }
+  let(:faraday_dbl) { class_double(Faraday) }
+  let(:url) { 'http://localhost:3000' }
+  let(:args) do
+    { druid: bare_druid, incoming_version: version, incoming_size: size, storage_location: strg_root }
+  end
+  let(:mock_so) do
+    instance_double(Moab::StorageObject, object_pathname: instance_double(Pathname), size: size, storage_root: strg_root, current_version_id: version)
+  end
+
+  before do
+    allow(Moab::StorageServices).to receive(:find_storage_object).and_return(mock_so)
+  end
+
+  describe '#perform' do
+    before do
+      allow(LyberCore::Log).to receive(:debug).with(any_args)
+      allow(Faraday).to receive(:new).with(url: url).and_return(faraday_dbl)
+    end
+
+    context 'object is new' do
+      it 'POST to /catalog' do
+        response = instance_double(Faraday::Response, status: 201)
+        expect(faraday_dbl).to receive(:post).with('/catalog', args).and_return(response)
+        expect(faraday_dbl).not_to receive(:patch)
+        update_catalog_obj.perform(bare_druid)
+      end
+    end
+
+    context 'object already exists' do
+      it 'PATCH to /catalog/:druid' do
+        response = instance_double(Faraday::Response, status: 409)
+        expect(faraday_dbl).to receive(:post).with('/catalog', args).and_return(response)
+        expect(faraday_dbl).to receive(:patch).with("/catalog/#{bare_druid}", args).and_return(response)
+        update_catalog_obj.perform(bare_druid)
+      end
+    end
+  end
+
+  describe '#conn' do
+    it 'calls Settings.preservation_catalog.url' do
+      response = instance_double(Faraday::Response, status: 201)
+      expect(Faraday).to receive(:new).with(url: Settings.preservation_catalog.url).and_return(faraday_dbl)
+      allow(faraday_dbl).to receive(:post).with('/catalog', args).and_return(response)
+      update_catalog_obj.perform(bare_druid)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,5 +12,6 @@ SimpleCov.start do
   add_filter 'config'
 end
 
-bootfile = File.join(File.dirname(__FILE__), '..', 'config/boot')
-require bootfile
+require File.join(File.dirname(__FILE__), '..', 'config/boot')
+
+Retries.sleep_enabled = false # skip delays during testing


### PR DESCRIPTION
~~_Note_: This is branched off `complete-ingest` robot #53  - *wait* until that is merged and then I will rebase.~~

~~Only need to review the last commit: `Pres_Robot#update_catalog`. Implements PC's catalog_controller w/ RSpec tests.~~


Was wondering if we should create a controller method for `check_existence` since that already handles some of the logic Joe and I implemented here... if the object does not exist `create`, if the object does exist, `update`.

paired w/ @atz
closes #7  