### PR TITLE
Tweak err msgs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,12 +55,12 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Max: 120 # this isn't 1994
   Exclude:
+    - config/schedule.rb # one long cli command
     - spec/preservation_ingest/complete_ingest_spec.rb
     - spec/preservation_ingest/transfer_object_spec.rb # some long lines with fully namespaced classes
     - spec/preservation_ingest/update_moab_spec.rb # one long ling with fully namespaced classes
     - spec/preservation_ingest/validate_bag_spec.rb # one long line with fully namespaced classes
     - spec/preservation_ingest/verify_apo_spec.rb # one long line with fully namespaced classes
-    - config/schedule.rb # one long cli command
 Metrics/MethodLength:
   Exclude:
     - robots/preservation_ingest/base.rb # execute_shell_command
@@ -82,8 +82,8 @@ RSpec/ContextWording:
 RSpec/ExampleLength:
   Max: 10
   Exclude:
-    - spec/preservation_ingest/transfer_object_spec.rb # lots of expectations to set up for some specs
     - spec/lib/stats_reporter_spec.rb # mimicking cli output takes many lines
+    - spec/preservation_ingest/transfer_object_spec.rb # lots of expectations to set up for some specs
 
 RSpec/FilePath:
   Enabled: false # paths become long to no gain

--- a/robots/preservation_ingest/complete_ingest.rb
+++ b/robots/preservation_ingest/complete_ingest.rb
@@ -30,7 +30,7 @@ module Robots
         def remove_deposit_bag
           deposit_bag_pathname.rmtree
         rescue StandardError => e
-          errmsg = "Error completing ingest: failed to remove deposit bag (#{deposit_bag_pathname}): " \
+          errmsg = "Error completing ingest for #{druid}: failed to remove deposit bag (#{deposit_bag_pathname}): " \
             "#{e.message}\n + e.backtrace.join('\n')"
           LyberCore::Log.error(errmsg)
           raise(ItemError, errmsg)
@@ -43,8 +43,8 @@ module Robots
           }
           workflow_service.update_workflow_status('dor', druid, 'accessionWF', 'sdr-ingest-received', 'completed', opts)
         rescue Dor::WorkflowException => e
-          errmsg = "Error completing ingest: failed to update accessionWF, sdr-ingest-received step, to completed: " \
-            "#{e.message}\n + e.backtrace.join('\n')"
+          errmsg = "Error completing ingest for #{druid}: failed to update " \
+            "accessionWF:sdr-ingest-received to completed: #{e.message}\n + e.backtrace.join('\n')"
           LyberCore::Log.error(errmsg)
           raise(ItemError, errmsg)
         end

--- a/robots/preservation_ingest/transfer_object.rb
+++ b/robots/preservation_ingest/transfer_object.rb
@@ -34,7 +34,7 @@ module Robots
           deposit_dir = prepare_deposit_dir
           self.class.execute_shell_command(tarpipe_command(deposit_dir))
         rescue StandardError => e
-          raise(ItemError, "Error transferring object: #{e.message}")
+          raise(ItemError, "Error transferring bag from common-accessioning for #{druid}: #{e.message}")
         end
 
         def prereqs_for_transfer
@@ -44,7 +44,7 @@ module Robots
 
         def verify_accesssion_wf_step_completed
           accession_status = workflow_service.get_workflow_status('dor', druid, 'accessionWF', 'sdr-ingest-transfer')
-          err_msg = "accessionWF:sdr-ingest-transfer status is #{accession_status}"
+          err_msg = "accessionWF:sdr-ingest-transfer status is #{accession_status} for #{druid}"
           raise(ItemError, err_msg) unless accession_status == 'completed'
         end
 

--- a/robots/preservation_ingest/validate_bag.rb
+++ b/robots/preservation_ingest/validate_bag.rb
@@ -25,7 +25,7 @@ module Robots
           LyberCore::Log.debug("#{ROBOT_NAME} #{druid} starting")
           deposit_bag_validator = Moab::DepositBagValidator.new(moab_object)
           validation_errors = deposit_bag_validator.validation_errors
-          raise(ItemError, "Bag validation failure(s): #{validation_errors}") if validation_errors.any?
+          raise(ItemError, "Bag validation failure(s) for #{druid}: #{validation_errors}") if validation_errors.any?
         end
       end
     end

--- a/spec/preservation_ingest/complete_ingest_spec.rb
+++ b/spec/preservation_ingest/complete_ingest_spec.rb
@@ -20,7 +20,7 @@ describe Robots::SdrRepo::PreservationIngest::CompleteIngest do
     it 'raises ItemError if it fails to remove the deposit bag' do
       expect(deposit_bag_pathname.exist?).to be true
       expect(deposit_bag_pathname).to receive(:rmtree).and_raise(StandardError, 'rmtree failed')
-      exp_msg = Regexp.escape("Error completing ingest: failed to remove deposit bag (#{deposit_bag_pathname}): rmtree failed")
+      exp_msg = Regexp.escape("Error completing ingest for #{druid}: failed to remove deposit bag (#{deposit_bag_pathname}): rmtree failed")
       expect { this_robot.perform(druid) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
       expect(deposit_bag_pathname.exist?).to be true
     end
@@ -29,7 +29,7 @@ describe Robots::SdrRepo::PreservationIngest::CompleteIngest do
       error = Dor::WorkflowException.new('foo')
       expect(Dor::WorkflowService).to receive(:update_workflow_status)
         .with('dor', druid, 'accessionWF', 'sdr-ingest-received', 'completed', instance_of(Hash)).and_raise(error)
-      exp_msg = "#{Regexp.escape('Error completing ingest: failed to update accessionWF, sdr-ingest-received step, to completed: ')}.*foo"
+      exp_msg = Regexp.escape("Error completing ingest for #{druid}: failed to update accessionWF:sdr-ingest-received to completed: ") + ".*foo"
       expect { this_robot.perform(druid) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
     end
 

--- a/spec/preservation_ingest/transfer_object_spec.rb
+++ b/spec/preservation_ingest/transfer_object_spec.rb
@@ -16,7 +16,7 @@ describe Robots::SdrRepo::PreservationIngest::TransferObject do
   it 'raises ItemError if sdr-ingest-transfer robot in accessionWF does not have status completed' do
     expect(Dor::WorkflowService).to receive(:get_workflow_status)
       .with('dor', druid, 'accessionWF', 'sdr-ingest-transfer').and_return('foo')
-    exp_msg = 'Error transferring object: accessionWF:sdr-ingest-transfer status is foo'
+    exp_msg = "Error transferring bag from common-accessioning for #{druid}: accessionWF:sdr-ingest-transfer status is foo for #{druid}"
     expect { xfer_obj.perform(druid) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, exp_msg)
   end
 
@@ -24,7 +24,7 @@ describe Robots::SdrRepo::PreservationIngest::TransferObject do
     allow(xfer_obj).to receive(:verify_accesssion_wf_step_completed)
     cmd_regex = Regexp.new(".*ssh #{Settings.transfer_object.from_host} test -e #{vm_file_path}.*")
     expect(Robots::SdrRepo::PreservationIngest::Base).to receive(:execute_shell_command).with(a_string_matching(cmd_regex)).and_return('no')
-    exp_msg = "Error transferring object: #{vm_file_path} not found"
+    exp_msg = "Error transferring bag from common-accessioning for #{druid}: #{vm_file_path} not found"
     expect { xfer_obj.perform(druid) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, exp_msg)
   end
 
@@ -59,7 +59,7 @@ describe Robots::SdrRepo::PreservationIngest::TransferObject do
       FileUtils.touch(deposit_bag_pathname + 'bagit_file.txt')
       expect(deposit_bag_pathname.exist?).to be true
       expect(deposit_bag_pathname).to receive(:rmtree).and_raise(StandardError, 'rmtree failed')
-      exp_msg = Regexp.escape("Error transferring object: Failed preparation of deposit dir #{deposit_bag_pathname}")
+      exp_msg = Regexp.escape("Error transferring bag from common-accessioning for #{druid}: Failed preparation of deposit dir #{deposit_bag_pathname}")
       expect { xfer_obj.perform(druid) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
       expect(deposit_bag_pathname.exist?).to be true
     end
@@ -76,7 +76,7 @@ describe Robots::SdrRepo::PreservationIngest::TransferObject do
     tarpipe_cmd = xfer_obj.send(:tarpipe_command, deposit_dir_pathname)
     allow(Robots::SdrRepo::PreservationIngest::Base).to receive(:execute_shell_command)
       .with(tarpipe_cmd).and_raise(StandardError, 'tarpipe failed')
-    exp_msg = Regexp.escape("Error transferring object: tarpipe failed")
+    exp_msg = Regexp.escape("Error transferring bag from common-accessioning for #{druid}: tarpipe failed")
     expect { xfer_obj.perform(druid) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
   end
 

--- a/spec/preservation_ingest/verify_apo_spec.rb
+++ b/spec/preservation_ingest/verify_apo_spec.rb
@@ -13,7 +13,7 @@ describe Robots::SdrRepo::PreservationIngest::VerifyApo do
         let(:id) { 'verify-apo-rel-md-no-isGovernedBy' }
 
         it 'raises ItemError' do
-          exp_msg = "Unable to find isGovernedBy node of relationshipMetadata"
+          exp_msg = "Unable to find isGovernedBy node of relationshipMetadata for #{id}"
           expect { verify_apo.perform(id) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, exp_msg)
         end
       end
@@ -22,7 +22,7 @@ describe Robots::SdrRepo::PreservationIngest::VerifyApo do
         let(:id) { 'verify-apo-rel-md-no-resource-attr' }
 
         it 'raises ItemError' do
-          exp_msg = "Unable to find 'resource' attribute for <isGovernedBy> in relationshipMetadata"
+          exp_msg = "Unable to find 'resource' attribute for <isGovernedBy> in relationshipMetadata for #{id}"
           expect { verify_apo.perform(id) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, exp_msg)
         end
       end
@@ -32,7 +32,7 @@ describe Robots::SdrRepo::PreservationIngest::VerifyApo do
 
         it 'raises ItemError' do
           rel_md_pathname = deposit_bag_pathname.join('data/metadata/relationshipMetadata.xml')
-          exp_msg = "^Unable to parse #{rel_md_pathname}: .*"
+          exp_msg = "^Unable to parse #{rel_md_pathname} .*#{id}"
           expect { verify_apo.perform(id) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
         end
       end
@@ -53,13 +53,13 @@ describe Robots::SdrRepo::PreservationIngest::VerifyApo do
       it "raises ItemError if the APO Moab's object_pathname is not a directory" do
         allow(mock_moab).to receive(:object_pathname).and_return(mock_object_pathname)
         expect(mock_object_pathname).to receive(:directory?).and_return(false)
-        exp_msg = "Governing APO object druid:aa000aa0000 not found"
+        exp_msg = "Governing APO object druid:aa000aa0000 not found for #{id}"
         expect { verify_apo.perform(id) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, exp_msg)
       end
 
       it "raises ItemError if the APO Moab's object_pathname is nil" do
         allow(mock_moab).to receive(:object_pathname)
-        exp_msg = "Governing APO object druid:aa000aa0000 not found"
+        exp_msg = "Governing APO object druid:aa000aa0000 not found for #{id}"
         expect { verify_apo.perform(id) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, exp_msg)
       end
     end
@@ -80,7 +80,7 @@ describe Robots::SdrRepo::PreservationIngest::VerifyApo do
       let(:id) { 'verify-apo-no-rel-md-v1' }
 
       it 'raises ItemError' do
-        exp_msg = "relationshipMetadata.xml not found in deposit bag"
+        exp_msg = "relationshipMetadata.xml not found in deposit bag for #{id}"
         expect { verify_apo.perform(id) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, exp_msg)
       end
     end
@@ -88,7 +88,7 @@ describe Robots::SdrRepo::PreservationIngest::VerifyApo do
       let(:id) { 'verify-apo-no-rel-md-no-version' }
 
       it 'raises ItemError' do
-        exp_msg = "Unable to determine deposit version"
+        exp_msg = "Unable to determine deposit version for #{id}"
         expect { verify_apo.perform(id) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, exp_msg)
       end
     end


### PR DESCRIPTION
In the course of working on scripts required by Ben, et. al., to surface errors, we discovered that the log lines that matched "ERROR" or "WARN" frequently didn't have the druid present.  This PR addresses that.

It also tweaks the language of a couple errors to be more precise / brief.