### PR TITLE
Converts pres_error bash script to ruby w/ tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,11 +46,16 @@ Layout/IndentHeredoc:
 
 Metrics/AbcSize:
   Exclude:
+    - lib/error_reporter.rb
     - robots/preservation_ingest/verify_apo.rb # verify_apo_moab is 16.76; couldn't think of a way to be clearer
 
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - lib/error_reporter.rb
 
 Metrics/LineLength:
   Max: 120 # this isn't 1994
@@ -62,10 +67,16 @@ Metrics/LineLength:
     - spec/preservation_ingest/update_moab_spec.rb # one long ling with fully namespaced classes
     - spec/preservation_ingest/validate_bag_spec.rb # one long line with fully namespaced classes
     - spec/preservation_ingest/verify_apo_spec.rb # one long line with fully namespaced classes
+    
 Metrics/MethodLength:
   Exclude:
+    - lib/error_reporter.rb
     - robots/preservation_ingest/base.rb # execute_shell_command
     - robots/preservation_ingest/update_catalog.rb # one too many line [11/10]
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - lib/error_reporter.rb
 
 # --- Naming ---
 
@@ -100,6 +111,7 @@ RSpec/MultipleExpectations:
 
 RSpec/NestedGroups:
   Exclude:
+    - spec/lib/error_reporter_spec.rb
     - spec/preservation_ingest/verify_apo_spec.rb # it goes to 4 but so does the logic
 
 # --- Style ---

--- a/Rakefile
+++ b/Rakefile
@@ -45,3 +45,10 @@ Workflow stats:
   REPORT
   File.open("#{ROBOT_ROOT}/log/weekly_stats.log", 'w') { |f| f.write(complete_report) }
 end
+
+desc 'retrieve preservation erorrs'
+task preservation_errors: [:environment] do
+  require File.expand_path(File.dirname(__FILE__) + '/lib/error_reporter')
+  error_reporter = ErrorReporter.new
+  error_reporter.output
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -15,3 +15,8 @@ every :sunday, at: '5am' do
   set :output, nil
   command "/bin/cat /var/log/preservation_robots/weekly_stats.log | mail -s 'Weekly preservation stats' sdr-discuss@lists.stanford.edu"
 end
+
+every 1.day, at: '5am' do
+  set :output, nil
+  rake 'preservation_errors', mailto: 'sdr2service@sul-sdr-services.stanford.edu'
+end

--- a/lib/error_reporter.rb
+++ b/lib/error_reporter.rb
@@ -1,0 +1,67 @@
+# generates text for a report on errors and warning in robot
+class ErrorReporter
+  require 'text-table'
+  require 'fileutils'
+  require 'date'
+
+  def output
+    table_generator.each { |table| puts table.to_s unless table.rows.empty? }
+  end
+
+  def table_generator(log_files=default_log_files)
+    stack = []
+    today = Time.now.to_date.to_s
+
+    log_files.each do |file|
+      unless File.exist?(file) && File.size(file) > 0
+        puts "EMPTY or NON-EXISTENT: #{file}"
+        next
+      end
+      File.readlines(file).each do |line|
+        line =~ /#{today}/ || next
+        line.chomp!
+        stack << line
+        if line =~ /ERROR/
+          error_table.rows << [file, stack.shift, today] if stack.size > 1
+          error_table.rows << [file, line, today]
+          next
+        end
+        if line =~ /WARN/
+          next if line =~ /resque-signals/
+          warning_table.rows << [file, line, today]
+        end
+        stack.pop if stack.size > 2
+      end
+    end
+    [error_table, warning_table]
+  end
+
+  private
+
+  def error_table
+    @error_table ||= begin
+      table = Text::Table.new
+      table.head = %w[workflow errors timestamp]
+      table
+    end
+  end
+
+  def warning_table
+    @warning_table ||= begin
+      table = Text::Table.new
+      table.head = %w[workflow warnings timestamp]
+      table
+    end
+  end
+
+  def default_log_files
+    [
+      "sdr_preservationIngestWF_transfer-object.log",
+      "sdr_preservationIngestWF_validate-bag.log",
+      "sdr_preservationIngestWF_verify-apo.log",
+      "sdr_preservationIngestWF_update-moab.log",
+      "sdr_preservationIngestWF_update-catalog.log",
+      "sdr_preservationIngestWF_complete-ingest.log"
+    ].map { |file| "#{Dir.pwd}/log/#{file}" }
+  end
+end

--- a/spec/fixtures/sdr_preservationIngestWF_transfer-object.log
+++ b/spec/fixtures/sdr_preservationIngestWF_transfer-object.log
@@ -1,0 +1,2 @@
+INFO [2017-04-27 11:07:36] (17545)  :: druid:db274ff1758 processing
+ERROR [2017-04-27 11:07:37] (17541)  :: Some Random Error

--- a/spec/fixtures/sdr_preservationIngestWF_validate-bag.log
+++ b/spec/fixtures/sdr_preservationIngestWF_validate-bag.log
@@ -1,0 +1,2 @@
+INFO [2017-04-27 11:07:36] (17545)  :: druid:db274ff1758 processing
+WARN [2017-04-27 11:07:37] (17541)  :: Some Random Warning

--- a/spec/lib/error_reporter_spec.rb
+++ b/spec/lib/error_reporter_spec.rb
@@ -1,0 +1,77 @@
+require 'error_reporter'
+describe ErrorReporter do
+  let(:error_reporter) { described_class.new }
+  let(:tables) { error_reporter.table_generator }
+  let(:error_table) { tables.first }
+  let(:warning_table) { tables.second }
+  let(:date) { "2017-04-27" }
+  let(:dbl_date) { instance_double(Time, to_date: date) }
+  let(:base_path) { "#{Dir.pwd}/spec/fixtures" }
+  let(:error_path) { "#{base_path}/sdr_preservationIngestWF_transfer-object.log" }
+  let(:warn_path) { "#{base_path}/sdr_preservationIngestWF_validate-bag.log" }
+
+  describe '#table_generator' do
+    context 'file does not exist' do
+      before do
+        allow(described_class.new).to receive(:default_log_files).and_return(["/fake/file/path"])
+      end
+      it 'returns an empty array' do
+        p Dir.pwd
+        expect(error_table.rows).to be_empty
+        expect(warning_table.rows).to be_empty
+      end
+    end
+    context 'file exists' do
+      before do
+        allow(error_reporter).to receive(:default_log_files).and_return([error_path])
+      end
+
+      context "file contains todays date" do
+        before do
+          allow(Time).to receive(:now).and_return(dbl_date)
+        end
+
+        context "file contains ERROR" do
+          let(:info_msg) { "INFO [2017-04-27 11:07:36] (17545)  :: druid:db274ff1758 processing" }
+          let(:error_msg) { "ERROR [2017-04-27 11:07:37] (17541)  :: Some Random Error" }
+
+          it 'outputs table' do
+            expect(error_table.rows).to eq [[error_path, info_msg, date], [error_path, error_msg, date]]
+          end
+        end
+        context "file does not contain ERROR" do
+          before do
+            allow(error_reporter).to receive(:default_log_files).and_return([warn_path])
+          end
+          it 'does not output table' do
+            expect(error_table.rows).to be_empty
+          end
+        end
+        context "file contains WARN" do
+          before do
+            allow(error_reporter).to receive(:default_log_files).and_return([warn_path])
+          end
+          let(:warn_msg) { "WARN [2017-04-27 11:07:37] (17541)  :: Some Random Warning" }
+
+          it 'outputs table' do
+            expect(warning_table.rows).to eq [[warn_path, warn_msg, date]]
+          end
+        end
+        context "file does not contain WARN" do
+          before do
+            allow(error_reporter).to receive(:default_log_files).and_return([error_path])
+          end
+          it 'does not output table' do
+            expect(warning_table.rows).to be_empty
+          end
+        end
+      end
+      context "file does not contain todays date" do
+        it 'does not output table' do
+          expect(warning_table.rows).to be_empty
+          expect(error_table.rows).to be_empty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Should I add reasons for why I'm adding error_reporter to rubocop exceptions?


closes #77 
closes #83