### PR TITLE
Separate reports

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nokogiri-happymapper (0.6.0)
       nokogiri (~> 1.5)

--- a/Rakefile
+++ b/Rakefile
@@ -46,6 +46,30 @@ Workflow stats:
   File.open("#{ROBOT_ROOT}/log/weekly_stats.log", 'w') { |f| f.write(complete_report) }
 end
 
+desc 'Generate storage stats'
+task generate_storage_stats: [:environment] do
+  require File.expand_path(File.dirname(__FILE__) + '/lib/stats_reporter')
+  stats_reporter = StatsReporter.new
+  storage_report = <<-REPORT.strip_heredoc
+Stats compiled on #{Time.now.to_date}
+Storage stats for mounts on #{Socket.gethostname}:
+#{stats_reporter.storage_report_text}
+  REPORT
+  File.open("#{ROBOT_ROOT}/log/storage_stats.log", 'w') { |f| f.write(storage_report) }
+end
+
+desc 'Generate workflow stats'
+task generate_wf_stats: [:environment] do
+  require File.expand_path(File.dirname(__FILE__) + '/lib/stats_reporter')
+  stats_reporter = StatsReporter.new
+  wf_report = <<-REPORT.strip_heredoc
+Stats compiled on #{Time.now.to_date}
+Workflow stats:
+#{stats_reporter.workflow_report_text}
+  REPORT
+  File.open("#{ROBOT_ROOT}/log/wf_stats.log", 'w') { |f| f.write(wf_report) }
+end
+
 desc 'get error and warning messages for each WF step'
 task preservation_errors: [:environment] do
   require File.expand_path(File.dirname(__FILE__) + '/lib/error_reporter')

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ rescue LoadError
   end
 end
 
-desc 'Generate stats'
+desc 'Generate all stats'
 task generate_stats: [:environment] do
   require File.expand_path(File.dirname(__FILE__) + '/lib/stats_reporter')
   stats_reporter = StatsReporter.new

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,12 +11,14 @@ end
 every :sunday, at: '4am' do
   set :output, nil
   set :environment_variable, 'ROBOT_ENVIRONMENT'
-  rake 'generate_stats'
+  rake 'generate_storage_stats'
+  rake 'generate_wf_stats'
 end
 
 every :sunday, at: '5am' do
   set :output, nil
-  command "/bin/cat /var/log/preservation_robots/weekly_stats.log | mail -s 'Weekly preservation stats' #{Settings.email_addresses.discussion_list}"
+  command "/bin/cat /var/log/preservation_robots/storage_stats.log | mail -s 'Weekly preservation storage stats' #{Settings.email_addresses.discussion_list}"
+  command "/bin/cat /var/log/preservation_robots/wf_stats.log | mail -f 'Weekly preservation workflow stats' #{Settings.email_addresses.discussion_list}"
 end
 
 every 1.day, at: '5am' do


### PR DESCRIPTION
Fixes #100 

The `generate_stats` task has been failing most likely because the call to workflow service to generate the count of archived objects for preservation ingest intermittently times out, even with a 5 minute grace period set in apache. That timeout prevents all stats from being reported. This PR separates storage stats reporting from workflow stats reporting, so that the former will be delivered even if the latter stats fail to generate. This will let Ben know about storage limits with time enough to plan provisioning new storage roots, which was the impetus for issuing the issue fixed. Not sure what the best path forward for addressing the workflow bottleneck, but considering it a separate issue.