### PR TITLE
Help schedule find log files

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -17,8 +17,8 @@ end
 
 every :sunday, at: '5am' do
   set :output, nil
-  command "/bin/cat /var/log/preservation_robots/storage_stats.log | mail -s 'Weekly preservation storage stats' #{Settings.email_addresses.discussion_list}"
-  command "/bin/cat /var/log/preservation_robots/wf_stats.log | mail -f 'Weekly preservation workflow stats' #{Settings.email_addresses.discussion_list}"
+  command "/bin/cat #{ROBOT_ROOT}/log/preservation_robots/storage_stats.log | mail -s 'Weekly preservation storage stats' #{Settings.email_addresses.discussion_list}"
+  command "/bin/cat #{ROBOT_ROOT}/log/preservation_robots/wf_stats.log | mail -f 'Weekly preservation workflow stats' #{Settings.email_addresses.discussion_list}"
 end
 
 every 1.day, at: '5am' do


### PR DESCRIPTION
This ought to resolve a recurring crontab error caused by not finding the app log files under `/var/log`. Note that I could not connect to `preservation-robots1-{stage,prod}` to troubleshoot this further, so I am putting this PR with less confidence than I would like. (And I have begun a discussion in Slack about not being able to connect.)