### PR TITLE
Update lyber-core to 5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ gem 'pry' # useful for production environment
 
 # Stanford DLSS gems
 gem 'moab-versioning', '>= 4.2.0' # work with Moab Objects; 4.2.0 has DepositBagValidator
-gem 'lyber-core', '~> 5.0' # robot code
+gem 'lyber-core', '~> 5.1' # robot code
+gem 'dor-services', '~> 7.0'
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'text-table' # to generate tables for StatsReporter
 gem 'whenever' # manage cron for robots and monitoring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.6.0)
+    dor-workflow-client (3.7.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)
@@ -157,8 +157,8 @@ GEM
       dry-equalizer (~> 0.2, >= 0.2.2)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    edtf (3.0.4)
-      activesupport (>= 3.0, < 6.0)
+    edtf (3.0.5)
+      activesupport (>= 3.0, < 7.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     faraday (0.15.4)
@@ -182,9 +182,10 @@ GEM
     iso-639 (0.2.8)
     json (2.2.0)
     link_header (0.0.8)
-    lyber-core (5.0.1)
+    lyber-core (5.1.0)
       activesupport
-      dor-services (~> 7.0)
+      dor-services (>= 7.0.0, < 9)
+      dor-workflow-client (~> 3.7)
     method_source (0.9.2)
     mime-types (3.3)
       mime-types-data (~> 3.2015)
@@ -373,9 +374,10 @@ DEPENDENCIES
   config
   coveralls
   dlss-capistrano
+  dor-services (~> 7.0)
   faraday
   honeybadger
-  lyber-core (~> 5.0)
+  lyber-core (~> 5.1)
   moab-versioning (>= 4.2.0)
   pry
   pry-byebug


### PR DESCRIPTION
This avoids hitting a deprecated endpoint in the workflow service