### PR TITLE
Switch to use preservation-client to do update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem 'lyber-core', '~> 5.1' # robot code
 gem 'dor-services', '~> 7.0'
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'text-table' # to generate tables for StatsReporter
+gem 'preservation-client', '~> 2.1'
 gem 'whenever' # manage cron for robots and monitoring
-gem 'faraday' # for ReST calls to Preservation Catalog
 gem 'retries'
 gem 'resque'
 gem 'resque-pool'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,11 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
+    preservation-client (2.1.0)
+      activesupport (>= 4.2, < 7)
+      faraday (~> 0.15)
+      moab-versioning (~> 4.3)
+      zeitwerk (~> 2.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -375,10 +380,10 @@ DEPENDENCIES
   coveralls
   dlss-capistrano
   dor-services (~> 7.0)
-  faraday
   honeybadger
   lyber-core (~> 5.1)
   moab-versioning (>= 4.2.0)
+  preservation-client (~> 2.1)
   pry
   pry-byebug
   rake

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,6 +1,8 @@
 # Ensure subsequent requires search the correct local paths
 require 'logger'
-require 'honeybadger'
+require 'rubygems'
+require 'bundler/setup'
+Bundler.require(:default)
 
 # Load the environment file based on Environment.  Default to development
 environment = ENV['ROBOT_ENVIRONMENT'] ||= 'development'
@@ -9,7 +11,6 @@ ROBOT_LOG = Logger.new(File.join(ROBOT_ROOT, "log/#{environment}.log"))
 ROBOT_LOG.level = Logger::SEV_LABEL.index(ENV['ROBOT_LOG_LEVEL']) || Logger::INFO
 
 # config gem, without Rails, requires we load the config ourselves
-require 'config'
 Config.setup do |config|
   config.use_env = true
   config.env_prefix = 'SETTINGS'
@@ -17,12 +18,10 @@ Config.setup do |config|
 end
 Config.load_and_set_settings(Config.setting_files(File.dirname(__FILE__), environment))
 
-require 'lyber_core'
 LyberCore::Log.set_logfile(Settings.lybercore_log)
 LyberCore::Log.set_level(ROBOT_LOG.level)
 
 # Load Resque configuration and controller
-require 'resque'
 redis_url = Settings.redis.url || "localhost:6379/resque:#{environment}"
 if defined? Settings.redis.timeout
   server, namespace = redis_url.split('/', 2)
@@ -37,7 +36,8 @@ Dor.configure do
   workflow.url Settings.workflow.url
 end
 
-require 'zeitwerk'
+Preservation::Client.configure(url: Settings.preservation_catalog.url)
+
 loader = Zeitwerk::Loader.new
 loader.push_dir(File.expand_path('lib'))
 loader.setup

--- a/spec/preservation_ingest/update_catalog_spec.rb
+++ b/spec/preservation_ingest/update_catalog_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateCatalog do
         end
 
         it 'fails' do
-          expect { update_catalog_obj.perform(bare_druid) }.to raise_error(Faraday::Error)
+          expect { update_catalog_obj.perform(bare_druid) }.to raise_error(Preservation::Client::UnexpectedResponseError)
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?
the Preservation-client provides an abstraction about how we talk to the preservation catalog. Additionally it has better error handling than we previously had here.

Fixes #182 and #183 

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a