### PR TITLE
pass auth token to preservation-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,7 @@ gem 'lyber-core', '~> 5.1' # robot code
 gem 'dor-services', '~> 7.0'
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'text-table' # to generate tables for StatsReporter
-# gem 'preservation-client', '~> 2.1'
-gem 'preservation-client', git: 'https://github.com/sul-dlss/preservation-client.git', branch: 'pass-jwt' # switch to official release once available
+gem 'preservation-client', '>= 3.0' # 3.x or greater is needed for token auth
 gem 'whenever' # manage cron for robots and monitoring
 gem 'retries'
 gem 'resque'

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ gem 'lyber-core', '~> 5.1' # robot code
 gem 'dor-services', '~> 7.0'
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'text-table' # to generate tables for StatsReporter
-gem 'preservation-client', '~> 2.1'
+# gem 'preservation-client', '~> 2.1'
+gem 'preservation-client', git: 'https://github.com/sul-dlss/preservation-client.git', branch: 'pass-jwt' # switch to official release once available
 gem 'whenever' # manage cron for robots and monitoring
 gem 'retries'
 gem 'resque'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/sul-dlss/preservation-client.git
-  revision: cab0eaabd6fed5fc7145675632c97963296a3e76
-  branch: pass-jwt
-  specs:
-    preservation-client (2.1.0)
-      activesupport (>= 4.2, < 7)
-      faraday (~> 0.15)
-      moab-versioning (~> 4.3)
-      zeitwerk (~> 2.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -246,6 +235,11 @@ GEM
     parser (2.7.0.2)
       ast (~> 2.4.0)
     powerpack (0.1.2)
+    preservation-client (3.0.0)
+      activesupport (>= 4.2, < 7)
+      faraday (>= 0.15, < 2.0)
+      moab-versioning (~> 4.3)
+      zeitwerk (~> 2.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -399,7 +393,7 @@ DEPENDENCIES
   honeybadger
   lyber-core (~> 5.1)
   moab-versioning (>= 4.2.0)
-  preservation-client!
+  preservation-client (>= 3.0)
   pry
   pry-byebug
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/sul-dlss/preservation-client.git
+  revision: cab0eaabd6fed5fc7145675632c97963296a3e76
+  branch: pass-jwt
+  specs:
+    preservation-client (2.1.0)
+      activesupport (>= 4.2, < 7)
+      faraday (~> 0.15)
+      moab-versioning (~> 4.3)
+      zeitwerk (~> 2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -235,11 +246,6 @@ GEM
     parser (2.7.0.2)
       ast (~> 2.4.0)
     powerpack (0.1.2)
-    preservation-client (2.1.0)
-      activesupport (>= 4.2, < 7)
-      faraday (~> 0.15)
-      moab-versioning (~> 4.3)
-      zeitwerk (~> 2.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -393,7 +399,7 @@ DEPENDENCIES
   honeybadger
   lyber-core (~> 5.1)
   moab-versioning (>= 4.2.0)
-  preservation-client (~> 2.1)
+  preservation-client!
   pry
   pry-byebug
   rake

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -36,7 +36,7 @@ Dor.configure do
   workflow.url Settings.workflow.url
 end
 
-Preservation::Client.configure(url: Settings.preservation_catalog.url)
+Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.auth_token)
 
 loader = Zeitwerk::Loader.new
 loader.push_dir(File.expand_path('lib'))

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,6 +33,7 @@ moab:
 
 preservation_catalog:
   url: 'http://localhost:3000'
+  auth_token: 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwcmVzZXJ2YXRpb25fcm9ib3RzIn0.cUW_P2o1eQFImKT4zVSJ9NrctVaE7h8TuBoSEpzPUVH0kQshz6S7XasotboxdmtEJj8kmCwXgr_ZZ6aUCTSCRg'
 
 email_addresses:
   discussion_list: 'user@discussion_list.org'


### PR DESCRIPTION
HOLD until: 

- [x] shared_configs PRs are merged (sul-dlss/shared_configs/pull/1177, sul-dlss/shared_configs/pull/1178)
- [x] test this branch on stage!
- [x] sul-dlss/preservation-client/pull/29 is merged
- [x] a new version of pres-client gem is released.
- [x] Fix this branch to use released gem
- [x] Take this PR out of draft

## Why was this change made?

pres cat will start requiring that all API clients supply an auth token, or their requests will be rejected as Unauthorized.

changes:
* change client configuration
* add supporting example setting (token generated by calling `rake generate_token` on my laptop and giving `preservation_robots` as the account name; default/public example pres cat HMAC secret was used)

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

N/A, i think

connects to https://github.com/sul-dlss/preservation_catalog/issues/1298
blocks https://github.com/sul-dlss/preservation_catalog/pull/1306
closes #187