### PR TITLE
change Settings to use token, not auth_token

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -36,7 +36,7 @@ Dor.configure do
   workflow.url Settings.workflow.url
 end
 
-Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.auth_token)
+Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.token)
 
 loader = Zeitwerk::Loader.new
 loader.push_dir(File.expand_path('lib'))

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -33,7 +33,7 @@ moab:
 
 preservation_catalog:
   url: 'http://localhost:3000'
-  auth_token: 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwcmVzZXJ2YXRpb25fcm9ib3RzIn0.cUW_P2o1eQFImKT4zVSJ9NrctVaE7h8TuBoSEpzPUVH0kQshz6S7XasotboxdmtEJj8kmCwXgr_ZZ6aUCTSCRg'
+  token: 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwcmVzZXJ2YXRpb25fcm9ib3RzIn0.cUW_P2o1eQFImKT4zVSJ9NrctVaE7h8TuBoSEpzPUVH0kQshz6S7XasotboxdmtEJj8kmCwXgr_ZZ6aUCTSCRg'
 
 email_addresses:
   discussion_list: 'user@discussion_list.org'


### PR DESCRIPTION
@jmartin-sul  - easy merge into your branch for draft PR.

## Why was this change made?

- @jmartin-sul and I discussed this and settled on "token" as the key
- to match our other Settings token keys (e.g. dor-services-app)
- to match our shared_configs (sul-dlss/shared_configs#1171 - 1178)

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a