### PR TITLE
preservation-client 3.1 fixes large POST requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'lyber-core', '~> 5.1' # robot code
 gem 'dor-services', '~> 7.0'
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'text-table' # to generate tables for StatsReporter
-gem 'preservation-client', '>= 3.0' # 3.x or greater is needed for token auth
+gem 'preservation-client', '>= 3.1' # 3.x or greater is needed for token auth
 gem 'whenever' # manage cron for robots and monitoring
 gem 'retries'
 gem 'resque'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
     parser (2.7.0.2)
       ast (~> 2.4.0)
     powerpack (0.1.2)
-    preservation-client (3.0.0)
+    preservation-client (3.1.0)
       activesupport (>= 4.2, < 7)
       faraday (>= 0.15, < 2.0)
       moab-versioning (~> 4.3)
@@ -392,7 +392,7 @@ DEPENDENCIES
   honeybadger
   lyber-core (~> 5.1)
   moab-versioning (>= 4.2.0)
-  preservation-client (>= 3.0)
+  preservation-client (>= 3.1)
   pry
   pry-byebug
   rake


### PR DESCRIPTION
## Why was this change made?

Part of sul-dlss/preservation-client#32 - POST requests to prescat were including params in the url, not in the request body.   preservation-client v3.1.0 fixes that problem.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a