### PR TITLE
Avoid LyberCore::Robot.step_to_classname

### DIFF
--- a/bin/run_robot.rb
+++ b/bin/run_robot.rb
@@ -3,12 +3,12 @@
 #
 # To run With Options
 # Options must be placed AFTER workflow and robot name
-# robot_root$ ./bin/run_robot dor:accessionWF:shelve -e test -d druid:aa12bb1234
+# robot_root$ ./bin/run_robot PreservationIngest::TransferObject -e test -d druid:aa12bb1234
 require 'bundler/setup'
 require 'slop'
 
 slop = Slop.new do
-  banner 'Usage: run_robot repo:workflow:step [options]'
+  banner 'Usage: run_robot class_name [options]'
   on :e, :environment=, 'Environment to run in (i.e. test, production). Defaults to development'
   on :d, :druid=, 'One druid to run the robot with'
   on :f, :file=, 'One file containing a druid per line'
@@ -26,11 +26,8 @@ opts = slop.to_h
 ENV['ROBOT_ENVIRONMENT'] = opts[:environment] unless opts[:environment].nil?
 require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 
-# generate the robot job class name
-class_name = LyberCore::Robot.step_to_classname robot
-
 # instantiate a Robot object using the name
-klazz = class_name.split('::').inject(Object) { |o, c| o.const_get c }
+klazz = robot.split('::').inject(Robots::SdrRepo) { |o, c| o.const_get c }
 bot = klazz.new
 bot.check_queued_status = false  # skipping the queued workflow status check
 


### PR DESCRIPTION


## Why was this change made?
It's deprecated because it's a lot more indirection than is required


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a