### PR TITLE
Upgrade to lyber-core 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,15 +6,16 @@ gem 'pry' # useful for production environment
 
 # Stanford DLSS gems
 gem 'moab-versioning', '>= 4.2.0' # work with Moab Objects; 4.2.0 has DepositBagValidator
-gem 'lyber-core', '~> 6.1' # robot code
 gem 'dor-services', '~> 7.0'
+gem 'dor-workflow-client', '~> 3.21'
 gem 'honeybadger' # for error reporting / tracking / notifications
-gem 'text-table' # to generate tables for StatsReporter
+gem 'lyber-core', '~> 6.1' # robot code
 gem 'preservation-client', '>= 3.1' # 3.x or greater is needed for token auth
-gem 'whenever' # manage cron for robots and monitoring
-gem 'retries'
 gem 'resque'
 gem 'resque-pool'
+gem 'retries'
+gem 'text-table' # to generate tables for StatsReporter
+gem 'whenever' # manage cron for robots and monitoring
 gem 'zeitwerk', '~> 2.1'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'pry' # useful for production environment
 
 # Stanford DLSS gems
 gem 'moab-versioning', '>= 4.2.0' # work with Moab Objects; 4.2.0 has DepositBagValidator
-gem 'lyber-core', '~> 5.1' # robot code
+gem 'lyber-core', '~> 6.1' # robot code
 gem 'dor-services', '~> 7.0'
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'text-table' # to generate tables for StatsReporter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.20.1)
+    dor-workflow-client (3.21.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (>= 0.9.2, < 2.0)
@@ -359,7 +359,7 @@ GEM
     tilt (2.0.10)
     tins (1.24.1)
       sync
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uber (0.0.15)
     unf (0.1.4)
@@ -387,6 +387,7 @@ DEPENDENCIES
   coveralls
   dlss-capistrano
   dor-services (~> 7.0)
+  dor-workflow-client (~> 3.21)
   honeybadger
   lyber-core (~> 6.1)
   moab-versioning (>= 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,10 +189,7 @@ GEM
     iso-639 (0.3.5)
     json (2.3.0)
     link_header (0.0.8)
-    lyber-core (5.5.1)
-      activesupport
-      dor-services (>= 7.0.0, < 9)
-      dor-workflow-client (~> 3.11)
+    lyber-core (6.1.1)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -391,7 +388,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-services (~> 7.0)
   honeybadger
-  lyber-core (~> 5.1)
+  lyber-core (~> 6.1)
   moab-versioning (>= 4.2.0)
   preservation-client (>= 3.1)
   pry

--- a/lib/robots/sdr_repo/preservation_ingest/base.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/base.rb
@@ -28,6 +28,10 @@ module Robots
           raise(StandardError, msg)
         end
 
+        def workflow_service
+          @workflow_service ||= WorkflowClientFactory.build
+        end
+
         private
 
         def moab_object

--- a/lib/robots/sdr_repo/preservation_ingest/base.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/base.rb
@@ -8,7 +8,6 @@ module Robots
       class Base
         include LyberCore::Robot
 
-        REPOSITORY = 'sdr'.freeze
         WORKFLOW_NAME = 'preservationIngestWF'.freeze
 
         attr_reader :druid

--- a/lib/robots/sdr_repo/preservation_ingest/complete_ingest.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/complete_ingest.rb
@@ -9,7 +9,7 @@ module Robots
         ROBOT_NAME = 'complete-ingest'.freeze
 
         def initialize(opts = {})
-          super(REPOSITORY, WORKFLOW_NAME, ROBOT_NAME, opts)
+          super(WORKFLOW_NAME, ROBOT_NAME, opts)
         end
 
         def perform(druid)

--- a/lib/robots/sdr_repo/preservation_ingest/transfer_object.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/transfer_object.rb
@@ -9,7 +9,7 @@ module Robots
         ROBOT_NAME = 'transfer-object'.freeze
 
         def initialize(opts = {})
-          super(REPOSITORY, WORKFLOW_NAME, ROBOT_NAME, opts)
+          super(WORKFLOW_NAME, ROBOT_NAME, opts)
         end
 
         def perform(druid)

--- a/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
@@ -13,7 +13,7 @@ module Robots
         ROBOT_NAME = 'update-catalog'.freeze
 
         def initialize(opts = {})
-          super(REPOSITORY, WORKFLOW_NAME, ROBOT_NAME, opts)
+          super(WORKFLOW_NAME, ROBOT_NAME, opts)
         end
 
         def perform(druid)

--- a/lib/robots/sdr_repo/preservation_ingest/update_moab.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/update_moab.rb
@@ -9,7 +9,7 @@ module Robots
         ROBOT_NAME = 'update-moab'.freeze
 
         def initialize(opts={})
-          super(REPOSITORY, WORKFLOW_NAME, ROBOT_NAME, opts)
+          super(WORKFLOW_NAME, ROBOT_NAME, opts)
         end
 
         def perform(druid)

--- a/lib/robots/sdr_repo/preservation_ingest/validate_bag.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/validate_bag.rb
@@ -9,7 +9,7 @@ module Robots
         ROBOT_NAME = 'validate-bag'.freeze
 
         def initialize(opts = {})
-          super(REPOSITORY, WORKFLOW_NAME, ROBOT_NAME, opts)
+          super(WORKFLOW_NAME, ROBOT_NAME, opts)
         end
 
         attr_reader :druid

--- a/lib/robots/sdr_repo/preservation_ingest/verify_apo.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/verify_apo.rb
@@ -15,7 +15,7 @@ module Robots
         VERSION_MD_FNAME = 'versionMetadata.xml'.freeze
 
         def initialize(opts = {})
-          super(REPOSITORY, WORKFLOW_NAME, ROBOT_NAME, opts)
+          super(WORKFLOW_NAME, ROBOT_NAME, opts)
         end
 
         def perform(druid)

--- a/lib/stats_reporter.rb
+++ b/lib/stats_reporter.rb
@@ -1,9 +1,8 @@
-# generates text for a report on storage root size and object status
+require 'text-table'
+require 'open3'
+
+# Generates text for a report on storage root size and object status
 class StatsReporter
-
-  require 'text-table'
-  require 'open3'
-
   def storage_report_text
     head = %w[filesystem total used pct_used free pct_free]
     Text::Table.new(head: head, rows: storage_report_lines).to_s
@@ -63,22 +62,14 @@ class StatsReporter
 
   def erroring_count
     ingest_wf_steps.map do |step|
-      # 4th argument is passed from the workflow client to the service which
-      # ignores it completely. Can remove once
-      # https://github.com/sul-dlss/dor-workflow-client/pull/159 is merged and
-      # released and made available in preservation_robots
-      workflow_client.count_objects_in_step(ingest_wf, step, 'error', nil)
+      workflow_client.count_objects_in_step(ingest_wf, step, 'error')
     end.sum
   rescue Dor::WorkflowException => exception
     "Error connecting to workflow service: #{exception.message}"
   end
 
   def completed_count
-    # 4th argument is passed from the workflow client to the service which
-    # ignores it completely. Can remove once
-    # https://github.com/sul-dlss/dor-workflow-client/pull/159 is merged and
-    # released and made available in preservation_robots
-    workflow_client.count_objects_in_step(ingest_wf, 'complete-ingest', 'completed', nil)
+    workflow_client.count_objects_in_step(ingest_wf, 'complete-ingest', 'completed')
   rescue Dor::WorkflowException => exception
     "Error connecting to workflow service: #{exception.message}"
   end
@@ -93,6 +84,6 @@ class StatsReporter
   end
 
   def workflow_client
-    Dor::Config.workflow.client
+    @workflow_client ||= WorkflowClientFactory.build
   end
 end

--- a/lib/stats_reporter.rb
+++ b/lib/stats_reporter.rb
@@ -19,10 +19,6 @@ class StatsReporter
     stdout_str
   end
 
-  def repository
-    'sdr'
-  end
-
   def ingest_wf
     'preservationIngestWF'
   end
@@ -56,24 +52,33 @@ class StatsReporter
   end
 
   def waiting_count
-    workflow_client.count_objects_in_step(ingest_wf, 'start-ingest',
-                                          'waiting', repository)
+    # 4th argument is passed from the workflow client to the service which
+    # ignores it completely. Can remove once
+    # https://github.com/sul-dlss/dor-workflow-client/pull/159 is merged and
+    # released and made available in preservation_robots
+    workflow_client.count_objects_in_step(ingest_wf, 'start-ingest', 'waiting', nil)
   rescue Dor::WorkflowException => exception
     "Error connecting to workflow service: #{exception.message}"
   end
 
   def erroring_count
     ingest_wf_steps.map do |step|
-      workflow_client.count_objects_in_step(ingest_wf, step,
-                                            'error', repository)
+      # 4th argument is passed from the workflow client to the service which
+      # ignores it completely. Can remove once
+      # https://github.com/sul-dlss/dor-workflow-client/pull/159 is merged and
+      # released and made available in preservation_robots
+      workflow_client.count_objects_in_step(ingest_wf, step, 'error', nil)
     end.sum
   rescue Dor::WorkflowException => exception
     "Error connecting to workflow service: #{exception.message}"
   end
 
   def completed_count
-    workflow_client.count_objects_in_step(ingest_wf, 'complete-ingest',
-                                          'completed', repository)
+    # 4th argument is passed from the workflow client to the service which
+    # ignores it completely. Can remove once
+    # https://github.com/sul-dlss/dor-workflow-client/pull/159 is merged and
+    # released and made available in preservation_robots
+    workflow_client.count_objects_in_step(ingest_wf, 'complete-ingest', 'completed', nil)
   rescue Dor::WorkflowException => exception
     "Error connecting to workflow service: #{exception.message}"
   end

--- a/lib/workflow_client_factory.rb
+++ b/lib/workflow_client_factory.rb
@@ -1,0 +1,7 @@
+# Build and return a workflow client instance
+class WorkflowClientFactory
+  def self.build
+    logger = Logger.new(Settings.workflow.logfile, Settings.workflow.shift_age)
+    Dor::Workflow::Client.new(url: Settings.workflow.url, logger: logger, timeout: Settings.workflow.timeout)
+  end
+end

--- a/spec/lib/stats_reporter_spec.rb
+++ b/spec/lib/stats_reporter_spec.rb
@@ -70,12 +70,6 @@ describe StatsReporter do
     end
   end
 
-  describe '.repository' do
-    it 'returns the repository attribute value in the preservationIngestWF xml' do
-      expect(stats_reporter.repository).to eq('sdr')
-    end
-  end
-
   describe '.ingest_wf' do
     it 'returns the workflow definition id from the preservationIngestWF xml' do
       expect(stats_reporter.ingest_wf).to eq('preservationIngestWF')

--- a/spec/preservation_ingest/complete_ingest_spec.rb
+++ b/spec/preservation_ingest/complete_ingest_spec.rb
@@ -27,7 +27,7 @@ describe Robots::SdrRepo::PreservationIngest::CompleteIngest do
 
     context 'if it fails to update the accessionWF sdr-ingest-received step' do
       before do
-        allow(Dor::Config.workflow.client).to receive(:update_status).and_raise(Dor::WorkflowException.new('foo'))
+        allow(this_robot.workflow_service).to receive(:update_status).and_raise(Dor::WorkflowException.new('foo'))
       end
 
       it 'raises ItemError' do
@@ -38,7 +38,7 @@ describe Robots::SdrRepo::PreservationIngest::CompleteIngest do
 
     it 'removes the deposit bag and updates the accessionWF when no errors are raised' do
       expect(deposit_bag_pathname).to receive(:rmtree)
-      expect(Dor::Config.workflow.client).to receive(:update_status)
+      expect(this_robot.workflow_service).to receive(:update_status)
         .with(druid: druid,
               workflow: 'accessionWF',
               process: 'sdr-ingest-received',


### PR DESCRIPTION
Fixes #207
Fixes sul-dlss/preservation_catalog#1459

## Why was this change made?

Stop sending the unused repository argument to LyberCore, and also, to the workflow client.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

No.

## Does this change affect how this application integrates with other services?

It affects how presbots talks to the workflow client. This PR removes a deprecated argument from being sent to the workflow service, which ignores it.