### PR TITLE
verify_apo robot should just verify object exists and is of type APO

### DIFF
--- a/lib/robots/sdr_repo/preservation_ingest/verify_apo.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/verify_apo.rb
@@ -28,8 +28,8 @@ module Robots
         def verify_governing_apo
           LyberCore::Log.debug("#{ROBOT_NAME} #{druid} starting")
           if relationship_md_pathname
-            verify_apo_moab
-            LyberCore::Log.debug("APO #{apo_druid} was verified")
+            verify_apo_registered
+            LyberCore::Log.debug("APO #{apo_druid} was verified as existing and of type APO")
           else
             errmsg = "relationshipMetadata.xml not found in deposit bag for #{druid}"
             raise(ItemError, errmsg) unless deposit_version > 1
@@ -42,9 +42,10 @@ module Robots
           @relationship_md_pathname if @relationship_md_pathname.file?
         end
 
-        def verify_apo_moab
-          apo_moab = Stanford::StorageServices.find_storage_object(apo_druid)
-          return if apo_moab && apo_moab.object_pathname && apo_moab.object_pathname.directory?
+        def verify_apo_registered
+          apo_object = Dor.find(apo_druid)
+          raise(ItemError, "Governing APO object #{apo_druid} not type APO object for #{druid}") unless apo_object.class == Dor::AdminPolicyObject
+        rescue ActiveFedora::ObjectNotFoundError
           raise(ItemError, "Governing APO object #{apo_druid} not found for #{druid}")
         end
 


### PR DESCRIPTION
## Why was this change made?

to deal with sul-dlss/argo#1801 by relaxing the verify_apo step to not check into preservation core


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?



## Does this change affect how this application integrates with other services?

If so, please confirm:
- change was tested on stage    and/or
- test added to sul-dlss/infrastructure-integration-test
