### PR TITLE
remove unused setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,7 +7,6 @@ lybercore_log: 'log/lybercore.log'
 # for workflows
 workflow:
   url: 'https://workflows.example.org'
-  dor_services_url: 'https://fakeuser:fakepass@fakeserver.example.edu/dor'
   logfile: 'log/workflow_service.log'
   shift_age: 'weekly'
   timeout: 60 # seconds


### PR DESCRIPTION
`dor_services_url` only appears in this config

## Why was this change made?

cruft removal

## How was this change tested?

will deploy to stage and test SDR object creation/versioning, and will make sure preservation succeeds

## Which documentation and/or configurations were updated?

config only PR