### PR TITLE
Script gets storage_roots from yml

### DIFF
--- a/bin/create_bag.rb
+++ b/bin/create_bag.rb
@@ -12,11 +12,14 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'moab/stanford'
+require 'yaml'
 
 include Stanford # rubocop:disable Style/MixinUsage
 
+settings = YAML.load_file('../config/environments/prod.yml')
+
 Moab::Config.configure do
-  storage_roots Dir.glob('/services-disk*').sort
+  storage_roots settings['moab']['storage_roots'].sort
   storage_trunk 'sdr2objects'
   deposit_trunk 'deposit'
   path_method 'druid_tree'


### PR DESCRIPTION
  ## Why was this change made?

1. To make the script aware of the differently named `/pres-01` storage root
2. To pull storage root info from configuration, instead of guessing about the filesystem

## How was this change tested?

Manually on the server.

## Which documentation and/or configurations were updated?

n/a

