### PR TITLE
update transfer_object example with correct host

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,7 @@ workflow:
 
 # where to find the deposit bag to be preserved
 transfer_object:
-  from_host: 'userid@common-accessioning-vm'
+  from_host: 'userid@dor-services-app'
   from_dir: '/dor/export/'
 
 ssl:


### PR DESCRIPTION
## Why was this change made?

the example suggested connecting to common-accessioning to perform the `transfer_object` work, but we should actually connect to dor-services-app.

## How was this change tested?

n/a, just changes a configuration example

## Which documentation and/or configurations were updated?

the example in the base settings.yml file.