### PR TITLE
Bump dependent gem versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,8 +68,8 @@ GEM
     deep_merge (1.2.1)
     deprecation (0.99.0)
       activesupport
-    diff-lcs (1.3)
-    dlss-capistrano (3.8.0)
+    diff-lcs (1.4.2)
+    dlss-capistrano (3.9.0)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key
@@ -103,7 +103,7 @@ GEM
       zeitwerk (~> 2.1)
     druid-tools (2.1.0)
       deprecation
-    dry-configurable (0.11.5)
+    dry-configurable (0.11.6)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
       dry-equalizer (~> 0.2)
@@ -207,7 +207,7 @@ GEM
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
-    preservation-client (3.2.0)
+    preservation-client (3.2.1)
       activesupport (>= 4.2, < 7)
       faraday (>= 0.15, < 2.0)
       moab-versioning (~> 4.3)


### PR DESCRIPTION
## Why was this change made?

Necessary to bump the preservation-client gem in support of #239 

## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A

