### PR TITLE
Test touchups

### DIFF
--- a/spec/preservation_ingest/update_moab_spec.rb
+++ b/spec/preservation_ingest/update_moab_spec.rb
@@ -6,12 +6,15 @@ describe Robots::SdrRepo::PreservationIngest::UpdateMoab do
   let(:verification_result) { instance_double(Moab::VerificationResult) }
 
   describe '#perform' do
+    before do
+      allow(Moab::StorageServices).to receive(:search_storage_objects).and_return(mock_storage_objects)
+    end
+
     context 'with a single moab' do
       let(:mock_storage_object) { instance_double(Moab::StorageObject, object_pathname: mock_path) }
       let(:mock_storage_objects) { [mock_storage_object] }
 
       before do
-        allow(Moab::StorageServices).to receive(:search_storage_objects).and_return(mock_storage_objects)
         allow(Moab::StorageServices).to receive(:find_storage_object).and_return(mock_storage_object)
       end
 
@@ -42,7 +45,6 @@ describe Robots::SdrRepo::PreservationIngest::UpdateMoab do
       let(:mock_storage_objects) { [mock_storage_object_1, mock_storage_object_2] }
 
       before do
-        allow(Moab::StorageServices).to receive(:search_storage_objects).and_return(mock_storage_objects)
         allow(Preservation::Client.objects).to receive(:primary_moab_location).and_return(mock_path.to_s)
       end
 

--- a/spec/preservation_ingest/update_moab_spec.rb
+++ b/spec/preservation_ingest/update_moab_spec.rb
@@ -1,9 +1,12 @@
 describe Robots::SdrRepo::PreservationIngest::UpdateMoab do
   let(:pres_update_moab) { described_class.new }
+  let(:storage_root_and_trunk) { 'storage_root1/sdr2objects' }
   let(:full_druid) { 'druid:bj102hs9687' }
-  let(:mock_path) { instance_double(Pathname) }
+  let(:mock_pathname) { DruidTools::Druid.new(full_druid, storage_root_and_trunk).pathname }
   let(:mock_new_version) { instance_double(Moab::StorageObjectVersion) }
   let(:verification_result) { instance_double(Moab::VerificationResult) }
+  let(:mock_storage_object) { instance_double(Moab::StorageObject, object_pathname: mock_pathname) }
+  let(:mock_storage_objects) { [mock_storage_object] }
 
   describe '#perform' do
     before do
@@ -11,9 +14,6 @@ describe Robots::SdrRepo::PreservationIngest::UpdateMoab do
     end
 
     context 'with a single moab' do
-      let(:mock_storage_object) { instance_double(Moab::StorageObject, object_pathname: mock_path) }
-      let(:mock_storage_objects) { [mock_storage_object] }
-
       before do
         allow(Moab::StorageServices).to receive(:find_storage_object).and_return(mock_storage_object)
       end
@@ -40,17 +40,18 @@ describe Robots::SdrRepo::PreservationIngest::UpdateMoab do
     end
 
     context 'with multiple moabs' do
-      let(:mock_storage_object_1) { instance_double(Moab::StorageObject, object_pathname: mock_path) }
-      let(:mock_storage_object_2) { instance_double(Moab::StorageObject, object_pathname: mock_path) }
-      let(:mock_storage_objects) { [mock_storage_object_1, mock_storage_object_2] }
+      let(:storage_root_and_trunk_2) { 'storage_root2/sdr2objects' }
+      let(:mock_pathname_2) { DruidTools::Druid.new(full_druid, storage_root_and_trunk_2).pathname }
+      let(:mock_storage_object_2) { instance_double(Moab::StorageObject, object_pathname: mock_pathname_2) }
+      let(:mock_storage_objects) { [mock_storage_object, mock_storage_object_2] }
 
       before do
-        allow(Preservation::Client.objects).to receive(:primary_moab_location).and_return(mock_path.to_s)
+        allow(Preservation::Client.objects).to receive(:primary_moab_location).and_return('storage_root2/sdr2objects')
       end
 
       it 'calls #ingest_bag and verify_version_storage on Moab::StorageObjectVersion' do
         allow(LyberCore::Log).to receive(:debug).with('update-moab druid:bj102hs9687 starting')
-        expect(mock_storage_object_1).to receive(:ingest_bag).and_return(mock_new_version)
+        expect(mock_storage_object_2).to receive(:ingest_bag).and_return(mock_new_version)
         allow(verification_result).to receive(:verified).and_return(true)
         expect(mock_new_version).to receive(:verify_version_storage).and_return(verification_result)
         pres_update_moab.perform(full_druid)


### PR DESCRIPTION
## Why was this change made?

to make tests slightly more realistic for the scenario where there are multiple moabs for the same druid among our storage roots.

## How was this change tested?

unit test only change.  no app code changes in this PR, just a bit of refinement on the existing tests (so that they can place slightly tighter and slightly more illustrative expectations on multi-moab behavior).

## Which documentation and/or configurations were updated?

n/a (other than a very slight improvement to the tests as documentation)
