### PR TITLE
configurable artificial delay right before update_catalog

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,3 +37,9 @@ preservation_catalog:
 email_addresses:
   discussion_list: 'user@discussion_list.org'
   user_list: 'user@user_list.org'
+
+# we expect/hope that this will not stay around forever.  see usage for further explanation.
+hacks:
+  update_catalog_sleep:
+    base_time: 0.05    # the default values are artificially low to keep test suite fast -- should override to be many seconds in prod
+    max_stagger: 0.01

--- a/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
@@ -33,12 +33,35 @@ module Robots
         end
 
         def update_catalog
+          wait_as_needed # give Ceph MDS some breathing room on the pres cat side, see comment on method
           with_retries(max_tries: 3, handler: handler, rescue: Preservation::Client::Error) do
             Preservation::Client.update(druid: druid,
                                         version: moab_object.current_version_id,
                                         size: moab_object.size,
                                         storage_location: moab_object.storage_root)
           end
+        end
+
+        # sleep for a configured amount of time, including a random additional delay to help ensure staggering.
+        #
+        # BUT WHY? at present we're having an issue with Ceph backed preservation storage that plays out something like:
+        # * a preservation_robots worker finishes writing a new version of a Moab to its druid tree in the storage trunk, from a bag
+        #   left in the deposit trunk.
+        # * the preservation_robots worker signals preservation_catalog that it has finished updating the Moab (update_catalog, above).
+        # * preservation_catalog, running on a different VM from the preservation_robots worker, attempts to read the Moab contents.
+        #   * unfortunately, the Ceph MDS (Metadata Server) that responds to a preservation_catalog VM sometimes lags in learning that the
+        #     preservation_robots VM that wrote the Moab has given up the original write lock, and then preservation_catalog effectively
+        #     has trouble fully reading the contents of the new Moab version.  In our experience, a locked file will sometimes not become
+        #     available to pres cat until the MDS instance is restarted.  Though sometimes it becomes available on its own tens of seconds later.
+        #   * usually this happens when trying to read and zip the Moab version for cloud replication in a later async pres cat job.  but sometimes
+        #     it happens when the more cursory version check on the pres cat side of the update_catalog API call is executed.
+        #   * so there's an argument for putting the delay on the other side, in the API implementation.  but putting a multi-second delay
+        #     in something that's already an asynchronous job feels less icky than putting it in a REST method implementation, and there's
+        #     inescapable interplay here between pres robots and pres cat anyway.
+        # we hope to figure out a way to further tune our Ceph setup so that this delay is no longer needed.
+        def wait_as_needed
+          additional_delay = rand(0.0..Settings.hacks.update_catalog_sleep.max_stagger)
+          sleep(Settings.hacks.update_catalog_sleep.base_time + additional_delay)
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?

in hopes of ameliorating lag between when pres robots finish writing a moab version, and when pres cat is fully able to read it.


## How was this change tested?

* unit tests cover the code change for basic functionality
* as a basic smoke test will deploy to stage and run infra integration tests and confirm preservation works, before deploying to prod.
  * will babysit in prod for a while after deployment

## Which documentation and/or configurations were updated?

added a couple settings, left explanation in code comments, since that seems like the most visible/useful place for the necessary info.