### PR TITLE
solo preservation robot

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,1 +1,1 @@
-"preservationIngestWF_default,preservationIngestWF_low": 10
+"preservationIngestWF_default,preservationIngestWF_low": 1


### PR DESCRIPTION
## Why was this change made?

see https://github.com/sul-dlss/preservation_catalog/issues/1633 ("preservation services are having trouble interacting reliably with Ceph backed storage")

@julianmorley's current hypothesis is that the concurrent linking and unlinking of many files (as the pres robots do via moab-versioning gem when updating a moab with a new version) can cause Ceph and its MDS instances to fall out of sync with the actual state of the stored file content, leading to reads from VMs that didn't write the content to sometimes fail.

this PR is an attempt to reduce that contention and test that theory.


## How was this change tested?

will deploy to stage


## Which documentation and/or configurations were updated?

n/a at the moment, will figure out documentation once the experimentation settles.