### PR TITLE
testing a small increase in concurrency

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,1 +1,1 @@
-"preservationIngestWF_default,preservationIngestWF_low": 1
+"preservationIngestWF_default,preservationIngestWF_low": 3


### PR DESCRIPTION
## Why was this change made?

we've still seen some issues retrieving file metadata, but pres robots and pres cat have not run into errors reading moabs with the greatly reduced pres robots worker count and the delay before update_catalog and before creating archive zips.

continuing to dial things back up slowly.

## How was this change tested?

will watch in prod and bring back down if we start seeing errors again.  should still be a low enough rate that we can easily shut down workers and manually clean up after a couple failed jobs if it looks like things aren't working out.  then revert to single worker and pause some automatic operations we don't currently have the capacity to keep up with consistently.

## Which documentation and/or configurations were updated?

n/a