### PR TITLE
keep re-adding preservationIngestWF workers

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,1 +1,2 @@
-"preservationIngestWF_default,preservationIngestWF_low": 3
+"preservationIngestWF_default,preservationIngestWF_low": 5
+"preservationIngestWF_low": 1


### PR DESCRIPTION
for now, have one dedicated to the `_low` queue, to help clear gbooks backlog

## Why was this change made?

to try and increase preservation throughput, and thus accessioning throughput, which has been degraded a bit due to https://github.com/sul-dlss/preservation_catalog/issues/1633

## How was this change tested?

will babysit in prod and look for an increase in errors.  will dial back down if problematic.

## Which documentation and/or configurations were updated?

just this resque-pool allocation