### PR TITLE
config/resque-pool.yml: return to 'normal' of 10 workers

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,2 +1,1 @@
-"preservationIngestWF_default,preservationIngestWF_low": 5
-"preservationIngestWF_low": 1
+"preservationIngestWF_default,preservationIngestWF_low": 10


### PR DESCRIPTION
## Why was this change made?

Julian believes he has addressed the problems with ceph storage so we can go back to our "regular" number of workers for preservation_robots

## How was this change tested?



## Which documentation and/or configurations were updated?



