### PR TITLE
Use dlss-capistrano to manage resque-pool

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -10,9 +10,9 @@ install_plugin Capistrano::SCM::Git
 require 'capistrano/bundler'
 
 require 'dlss/capistrano'
+require 'dlss/capistrano/resque_pool'
 require 'capistrano/honeybadger'
 require 'whenever/capistrano'
-require 'capistrano-resque-pool'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -34,5 +34,4 @@ end
 group :deployment do
   gem 'capistrano-bundler'
   gem 'dlss-capistrano'
-  gem 'capistrano-resque-pool'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,9 +46,6 @@ GEM
       capistrano (~> 3.1)
     capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
-    capistrano-resque-pool (0.2.0)
-      capistrano
-      resque-pool
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
     coderay (1.1.3)
@@ -68,7 +65,7 @@ GEM
     deprecation (0.99.0)
       activesupport
     diff-lcs (1.4.4)
-    dlss-capistrano (3.9.0)
+    dlss-capistrano (3.10.1)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key
@@ -362,7 +359,6 @@ PLATFORMS
 
 DEPENDENCIES
   capistrano-bundler
-  capistrano-resque-pool
   config
   coveralls
   dlss-capistrano

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -20,6 +20,7 @@ set :deploy_to, "/opt/app/pres/#{fetch(:application)}"
 # Default value for :linked_files is []
 # append :linked_files, "config/database.yml", "config/secrets.yml"
 # append :linked_files, %w(config/honeybadger.yml)
+append :linked_files, 'tmp/resque-pool.lock'
 
 # Default value for linked_dirs is []
 # append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
@@ -47,5 +48,3 @@ set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 
 # update shared_configs before restarting app
 before 'deploy:publishing', 'shared_configs:update'
-
-after 'deploy:publishing', 'resque:pool:hot_swap'


### PR DESCRIPTION
This replaces capistrano-resque-pool and works as expected with a hot-swappable pool.

Also includes:

Store resque-pool lockfile in shared dir
This allows the resque:pool:hot_swap capistrano task to do what we expect it to do.
