### PR TITLE
Do not allow dlss-capistrano to regress to 3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,5 +33,5 @@ end
 
 group :deployment do
   gem 'capistrano-bundler'
-  gem 'dlss-capistrano'
+  gem 'dlss-capistrano', '~> 3.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,9 +38,10 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundle_audit (0.2.1)
+    capistrano-bundle_audit (0.4.0)
       bundler-audit (~> 0.5)
       capistrano (~> 3.0)
+      capistrano-bundler (>= 1.4)
     capistrano-bundler (2.0.1)
       capistrano (~> 3.1)
     capistrano-one_time_key (0.1.0)
@@ -65,9 +66,9 @@ GEM
     deprecation (0.99.0)
       activesupport
     diff-lcs (1.4.4)
-    dlss-capistrano (3.5.0)
+    dlss-capistrano (3.11.1)
       capistrano (~> 3.0)
-      capistrano-bundle_audit (>= 0.1.0)
+      capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.5)
@@ -364,7 +365,7 @@ DEPENDENCIES
   capistrano-bundler
   config
   coveralls
-  dlss-capistrano
+  dlss-capistrano (~> 3.11)
   dor-services (~> 9.1)
   dor-workflow-client (~> 3.21)
   honeybadger


### PR DESCRIPTION
Fixes broken deployments due to missing resque_pool require

