### PR TITLE
robot step should not complete after API call is made to start job

### DIFF
--- a/lib/robots/sdr_repo/preservation_ingest/validate_moab.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/validate_moab.rb
@@ -15,6 +15,7 @@ module Robots
         def perform(druid)
           @druid = druid # for base class attr_accessor
           validate_moab
+          LyberCore::Robot::ReturnState.new(status: :noop, note: 'Initiated validate-moab API call.')
         end
 
         private


### PR DESCRIPTION
## Why was this change made?

Follow on work from #321 --- we do not want to mark the validate-moab step as complete after we make the API call, since the API call is starting an async job, which will mark the step as complete when the job is done.

## How was this change tested?



## Which documentation and/or configurations were updated?



