### PR TITLE
Deploy all workers to robots2-qa/stage

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,4 +1,5 @@
-server 'preservation-robots1-qa.stanford.edu', user: 'pres', roles: %w[web app db]
+# robots1-qa is temporarily out of service, robots2-qa picks up the slack
+# server 'preservation-robots1-qa.stanford.edu', user: 'pres', roles: %w[web app db]
 server 'preservation-robots2-qa.stanford.edu', user: 'pres', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,4 +1,5 @@
-server 'preservation-robots1-stage.stanford.edu', user: 'pres', roles: %w[web app db]
+# robots1-stage is temporarily out of service, robots2-stage picks up the slack
+# server 'preservation-robots1-stage.stanford.edu', user: 'pres', roles: %w[web app db]
 server 'preservation-robots2-stage.stanford.edu', user: 'pres', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,1 +1,1 @@
-"preservationIngestWF_default,preservationIngestWF_low": 5
+"preservationIngestWF_default,preservationIngestWF_low": 10


### PR DESCRIPTION
## Why was this change made?

robots2 machines will deploy all workers while robot1 machines are migrated to Ubuntu

## How was this change tested?

Manual testing with John and Andrew confirmed that robots2 machines are working

## Which documentation and/or configurations were updated?

DevOpsDocs PR upcoming

