### PR TITLE
Deploy to robots2-prod

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,4 +1,6 @@
-server 'preservation-robots1-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
+# while rebuilding robots1 as Ubuntu, robots2 picks up the slack
+# server 'preservation-robots1-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
+server 'preservation-robots2-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,1 +1,1 @@
-"preservationIngestWF_default,preservationIngestWF_low": 5
+"preservationIngestWF_default,preservationIngestWF_low": 10


### PR DESCRIPTION
## Why was this change made?

To take robots1-prod out of service to rebuild it as Ubuntu

## How was this change tested?

cap prod deploy:check

## Which documentation and/or configurations were updated?

DevOpsDocs PR forthcoming

