### PR TITLE
"Load balance" prod workers onto ubuntu machines

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,5 +1,4 @@
-# while rebuilding robots1 as Ubuntu, robots2 picks up the slack
-# server 'preservation-robots1-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
+server 'preservation-robots1-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
 server 'preservation-robots2-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,1 +1,1 @@
-"preservationIngestWF_default,preservationIngestWF_low": 10
+"preservationIngestWF_default,preservationIngestWF_low": 5


### PR DESCRIPTION
## Why was this change made?

1-prod is migrated to Ubuntu and ready to 'load balance' workers

## How was this change tested?

cap prod deploy:check

## Which documentation and/or configurations were updated?

DevOpsDocs PR forthcoming

