### PR TITLE
Fix string escaping for an error message

### DIFF
--- a/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
@@ -60,7 +60,7 @@ module Robots
           rm_deposit_bag_safely_for_ceph
         rescue StandardError => e
           errmsg = "Error completing ingest for #{druid}: failed to remove deposit bag (#{deposit_bag_pathname}): " \
-            "#{e.message}\n + e.backtrace.join('\n')"
+            "#{e.message}\n #{e.backtrace.join('\n')}"
           LyberCore::Log.error(errmsg)
           raise(ItemError, errmsg)
         end


### PR DESCRIPTION
## Why was this change made?

Fixes this problem where it logs ruby code rather than a backtrace:
<img width="766" alt="Screen Shot 2021-10-21 at 2 39 13 PM" src="https://user-images.githubusercontent.com/92044/138345540-c2d46e57-9106-4dd8-9de1-2db0c08d90cf.png">

## How was this change tested?





## Which documentation and/or configurations were updated?



