### PR TITLE
robots2-qa/stage/prod are 'warm standbys'

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,5 +1,6 @@
 server 'preservation-robots1-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
-server 'preservation-robots2-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
+# # robots2-prod is a warm standby - no resque-pool up but ready to deploy to if needed
+# server 'preservation-robots2-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,5 +1,6 @@
 server 'preservation-robots1-qa.stanford.edu', user: 'pres', roles: %w[web app db]
-server 'preservation-robots2-qa.stanford.edu', user: 'pres', roles: %w[web app db]
+# robots2-qa is a warm standby - no resque-pool up but ready to deploy to if needed
+# server 'preservation-robots2-qa.stanford.edu', user: 'pres', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,5 +1,6 @@
 server 'preservation-robots1-stage.stanford.edu', user: 'pres', roles: %w[web app db]
-server 'preservation-robots2-stage.stanford.edu', user: 'pres', roles: %w[web app db]
+# robots2-stage is a warm standby - no resque-pool up but ready to deploy to if needed
+# server 'preservation-robots2-stage.stanford.edu', user: 'pres', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,1 +1,1 @@
-"preservationIngestWF_default,preservationIngestWF_low": 5
+"preservationIngestWF_default,preservationIngestWF_low": 10


### PR DESCRIPTION
## Why was this change made?

We suspect running two robots machines in parallel is causing production issues

But there's still value in having a 'warm standby'

## How was this change tested?

cap deploy:check doesn't try to deploy to the 2nd robots box

## Which documentation and/or configurations were updated?

DevOpsDocs PR forthcoming

