### PR TITLE
Restore a require for find

### DIFF
--- a/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
@@ -2,6 +2,7 @@
 
 require 'faraday'
 require 'retries'
+require 'find'
 
 # Robot package to run under multiplexing infrastructure
 module Robots


### PR DESCRIPTION

## Why was this change made? 🤔

This used to happen in https://github.com/sul-dlss/moab-versioning/commit/8fb25738035b2d946ecb1fa4e593ddf2dcb73bb4#diff-0cd392e4dd653c44763db5e5228a82457c22a2f086a9e58893c87a4277d79cd4L3
Fixes #383 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


