### PR TITLE
Remove an unnecessary require of Faraday

### DIFF
--- a/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday'
 require 'retries'
 
 # Robot package to run under multiplexing infrastructure


### PR DESCRIPTION
## Why was this change made? 🤔

We don't use faraday in here.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


