### PR TITLE
touch up overview comment for convoluted method #moab_object

### DIFF
--- a/lib/robots/sdr_repo/preservation_ingest/base.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/base.rb
@@ -45,11 +45,17 @@ module Robots
         end
 
         def moab_object
+          # overview:
+          # * if there are multiple copies among the storage roots, ask pres cat which one is the primary
+          # * if there's only one copy, that's implicitly the primary
+          # * if a primary can't be determined from the above operations, that's an unexpected error
+          #   state and a human should intervene and figure things out (and the WF step should fail).
+          #
           # StorageServices.search_storage_objects won't return us what we want if the object version is
           # still mid-deposit in the preservation workflow -- see https://github.com/sul-dlss/moab-versioning/issues/167
-          # as such, use it to see if there are multiple copies already preserved among different storage roots.
-          # if there are, use the location for the primary according to pres cat to pick the storage location to update.
-          # if there are not multiple copies already preserved, use find_storage_object and include the deposit
+          # As such, use it to see if there are multiple copies already preserved among different storage roots.
+          # If there are, use the location for the primary according to pres cat to pick the storage location to update.
+          # If there are not multiple copies already preserved, use find_storage_object and include the deposit
           # folders -- this will return a storage object pointing to the correct storage root (which will be the last one
           # listed in the configs if this is the first version being preserved).
           existing_moabs = Stanford::StorageServices.search_storage_objects(druid)


### PR DESCRIPTION
## Why was this change made? 🤔

clarification per [discussion in slack](https://stanfordlib.slack.com/archives/C09M7P91R/p1652294661181109?thread_ts=1652292049.152089&cid=C09M7P91R).

there was other discussion in that thread about possibly further simplifying the method by not calling `find_storage_object` and just using the first result from `search_storage_objects` instead.  after re-reading the existing method comment, i'm not as sure that'll work.  worth looking into, and either way can probably edit this comment down.  but wanted to get this clarification in since it was requested last week, and i'm about to be out for a week.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


