### PR TITLE
temporarily set worker counts to zero, to prevent running preservation ingest

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,1 +1,2 @@
-"preservationIngestWF_default,preservationIngestWF_low": 10
+# "preservationIngestWF_default,preservationIngestWF_low": 10
+"preservationIngestWF_default,preservationIngestWF_low": 0


### PR DESCRIPTION
## Why was this change made? 🤔

per https://github.com/sul-dlss/preservation_catalog/issues/1896, stanford is currently experience campus-wide networking issues as a result of an ongoing multi-day electrical power outage/reduction.  per conversation with @andrewjbtw and @julianmorley on slack yesterday, we're pausing the accessioning pipeline until power/network stability is restored.  per conversation with @ndushay and @justinlittman in standup today, we're zeroing the worker count in common-accessioning and preservation_robots, so that monday's FR (@jcoyne) doesn't have to worry about stopping resque-pool when deploying dependency updates, if the outage is still ongoing.

once network stability is restored, we should revert this change.

## How was this change tested? 🤨

we've used this pattern a number of times in the past for stopping workers from picking up jobs? 🤷 (see e.g. preservation catalog storage migrations, fedora VM migration)

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


