### PR TITLE
re-enable preservation robots

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,2 +1,1 @@
-# "preservationIngestWF_default,preservationIngestWF_low": 10
-"preservationIngestWF_default,preservationIngestWF_low": 0
+"preservationIngestWF_default,preservationIngestWF_low": 10


### PR DESCRIPTION
## Why was this change made? 🤔

got the go ahead yesterday from @andrewjbtw to let preservationIngestWF start processing again.


## How was this change tested? 🤨

just restoring the prior working configuration

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


