### PR TITLE
Remove capistrano-rvm dependency

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -15,7 +15,6 @@ require 'dlss/capistrano'
 require 'dlss/capistrano/resque_pool'
 require 'capistrano/honeybadger'
 require 'whenever/capistrano'
-require 'capistrano/rvm'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,4 @@ end
 group :deployment do
   gem 'capistrano-bundler'
   gem 'dlss-capistrano', require: false
-  gem 'capistrano-rvm'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,9 +28,6 @@ GEM
       capistrano (~> 3.1)
     capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
     coderay (1.1.3)
@@ -224,7 +221,6 @@ PLATFORMS
 
 DEPENDENCIES
   capistrano-bundler
-  capistrano-rvm
   config
   dlss-capistrano
   dor-workflow-client (~> 5.0)
@@ -251,4 +247,4 @@ DEPENDENCIES
   zeitwerk (~> 2.1)
 
 BUNDLED WITH
-   2.3.17
+   2.3.22


### PR DESCRIPTION
## Why was this change made? 🤔

This commit removes capistrano-rvm, a dependency we no longer need. Done because it is on the FR board.



## How was this change tested? 🤨

Deployed to stage.
