### PR TITLE
stop using search_storage_objects as we don't use multiple moab

### DIFF
--- a/lib/robots/sdr_repo/preservation_ingest/base.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/base.rb
@@ -45,34 +45,7 @@ module Robots
         end
 
         def moab_object
-          # overview:
-          # * if there are multiple copies among the storage roots, ask pres cat which one is the primary
-          # * if there's only one copy, that's implicitly the primary
-          # * if a primary can't be determined from the above operations, that's an unexpected error
-          #   state and a human should intervene and figure things out (and the WF step should fail).
-          #
-          # StorageServices.search_storage_objects won't return us what we want if the object version is
-          # still mid-deposit in the preservation workflow -- see https://github.com/sul-dlss/moab-versioning/issues/167
-          # As such, use it to see if there are multiple copies already preserved among different storage roots.
-          # If there are, use the location for the primary according to pres cat to pick the storage location to update.
-          # If there are not multiple copies already preserved, use find_storage_object and include the deposit
-          # folders -- this will return a storage object pointing to the correct storage root (which will be the last one
-          # listed in the configs if this is the first version being preserved).
-          existing_moabs = Stanford::StorageServices.search_storage_objects(druid)
-          @moab_object ||=
-            if existing_moabs.size > 1
-              # if we see more than one among the storage roots, ask pres cat to choose a primary
-              existing_moabs.find { |moab| moab.object_pathname.to_s.start_with?(primary_moab_location) }
-            else
-              Stanford::StorageServices.find_storage_object(druid, true)
-            end
-        rescue Preservation::Client::NotFoundError
-          raise "#{druid} - Multiple copies of Moab exist among storage roots, but Preservation Catalog has no primary location for it"
-        end
-
-        # @raise [Preservation::Client::NotFoundError]
-        def primary_moab_location
-          @primary_moab_location ||= Preservation::Client.objects.primary_moab_location(druid: druid)
+          @moab_object ||= Stanford::StorageServices.find_storage_object(druid, true)
         end
 
         def deposit_bag_pathname

--- a/spec/preservation_ingest/transfer_object_spec.rb
+++ b/spec/preservation_ingest/transfer_object_spec.rb
@@ -37,11 +37,9 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::TransferObject do
 
   describe 'creating a path for the deposit bag' do
     let(:mock_moab) { instance_double(Moab::StorageObject, deposit_bag_pathname: deposit_bag_pathname) }
-    let(:mock_moabs) { [mock_moab] }
 
     before do
       allow(xfer_obj).to receive(:verify_version_metadata)
-      allow(Stanford::StorageServices).to receive(:search_storage_objects).and_return(mock_moabs)
       allow(Stanford::StorageServices).to receive(:find_storage_object).and_return(mock_moab)
     end
 
@@ -74,12 +72,10 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::TransferObject do
 
   context 'when there is an error executing the transfer' do
     let(:mock_moab) { instance_double(Moab::StorageObject, deposit_bag_pathname: deposit_bag_pathname) }
-    let(:mock_moabs) { [mock_moab] }
     let(:exp_msg) { Regexp.escape("Error transferring bag (via userid@dor-services-app) for #{druid}: tarpipe failed") }
 
     before do
       allow(xfer_obj).to receive(:verify_version_metadata)
-      allow(Stanford::StorageServices).to receive(:search_storage_objects).and_return(mock_moabs)
       allow(Stanford::StorageServices).to receive(:find_storage_object).and_return(mock_moab)
       allow(Open3).to receive(:pipeline_r).and_raise(StandardError, 'tarpipe failed')
     end
@@ -93,12 +89,10 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::TransferObject do
 
   context 'when no errors are raised' do
     let(:mock_moab) { instance_double(Moab::StorageObject, deposit_bag_pathname: deposit_bag_pathname) }
-    let(:mock_moabs) { [mock_moab] }
     let(:cmd_regex) { Regexp.new("if ssh #{Settings.transfer_object.from_host} test -e #{vm_file_path}.*") }
 
     before do
       allow(Robots::SdrRepo::PreservationIngest::Base).to receive(:execute_shell_command).and_return('yes')
-      allow(Stanford::StorageServices).to receive(:search_storage_objects).and_return(mock_moabs)
       allow(Stanford::StorageServices).to receive(:find_storage_object).and_return(mock_moab)
     end
 
@@ -109,7 +103,6 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::TransferObject do
         'ssh userid@dor-services-app "tar -C /dor/export/ --dereference -cf - jc837rq9922 "', /^tar -C/
       )
       expect(Robots::SdrRepo::PreservationIngest::Base).to have_received(:execute_shell_command).with(a_string_matching(cmd_regex))
-      expect(Stanford::StorageServices).to have_received(:search_storage_objects)
       expect(Stanford::StorageServices).to have_received(:find_storage_object)
     end
   end

--- a/spec/preservation_ingest/update_catalog_spec.rb
+++ b/spec/preservation_ingest/update_catalog_spec.rb
@@ -20,25 +20,22 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateCatalog do
     }
   end
   let(:mock_storage_object) do
-    instance_double(Moab::StorageObject, deposit_bag_pathname: deposit_bag_pathname, object_pathname: mock_moab_pathname, size: size, storage_root: strg_root, current_version_id: version)
+    instance_double(Moab::StorageObject,
+                    deposit_bag_pathname: deposit_bag_pathname,
+                    object_pathname: mock_moab_pathname,
+                    size: size,
+                    storage_root: strg_root,
+                    current_version_id: version)
   end
-  let(:mock_storage_objects) { [mock_storage_object] }
-
   let(:spec_dir) { File.join(File.dirname(__FILE__), '..') }
   let(:deposit_dir_pathname) { Pathname(File.join(spec_dir, 'fixtures', 'deposit', 'update-catalog')) }
   let(:deposit_bag_pathname) { Pathname(File.join(deposit_dir_pathname, bare_druid)) }
   let(:mock_moab_pathname) { Pathname(File.realpath(File.join(spec_dir, 'fixtures', 'sdr2objects', 'bz', '514', 'sm', '9647', 'bz514sm9647'))) }
 
-  before do
-    allow(Moab::StorageServices).to receive(:search_storage_objects).and_return(mock_storage_objects)
-    allow(Moab::StorageServices).to receive(:find_storage_object).and_return(mock_storage_object)
-  end
-
   describe '#perform' do
     before do
       allow(LyberCore::Log).to receive(:debug).with(any_args)
       allow(deposit_bag_pathname).to receive(:rmtree)
-      allow(Moab::StorageServices).to receive(:search_storage_objects).and_return(mock_storage_objects)
       allow(Moab::StorageServices).to receive(:find_storage_object).and_return(mock_storage_object)
       FileUtils.mkdir_p(deposit_bag_pathname)
       FileUtils.touch("#{deposit_bag_pathname}bagit_file.txt")

--- a/spec/preservation_ingest/update_moab_spec.rb
+++ b/spec/preservation_ingest/update_moab_spec.rb
@@ -8,13 +8,8 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateMoab do
   let(:mock_new_version) { instance_double(Moab::StorageObjectVersion) }
   let(:verification_result) { instance_double(Moab::VerificationResult) }
   let(:mock_storage_object) { instance_double(Moab::StorageObject, object_pathname: mock_pathname) }
-  let(:mock_storage_objects) { [mock_storage_object] }
 
   describe '#perform' do
-    before do
-      allow(Moab::StorageServices).to receive(:search_storage_objects).and_return(mock_storage_objects)
-    end
-
     context 'with a single moab' do
       before do
         allow(Moab::StorageServices).to receive(:find_storage_object).and_return(mock_storage_object)
@@ -38,25 +33,6 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateMoab do
         allow(verification_result).to receive(:entity).and_return(full_druid_vers)
         expect(LyberCore::Log).to receive(:info).with('some_json')
         expect { pres_update_moab.perform(full_druid) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, error_message)
-      end
-    end
-
-    context 'with multiple moabs' do
-      let(:storage_root_and_trunk_2) { 'storage_root2/sdr2objects' }
-      let(:mock_pathname_2) { DruidTools::Druid.new(full_druid, storage_root_and_trunk_2).pathname }
-      let(:mock_storage_object_2) { instance_double(Moab::StorageObject, object_pathname: mock_pathname_2) }
-      let(:mock_storage_objects) { [mock_storage_object, mock_storage_object_2] }
-
-      before do
-        allow(Preservation::Client.objects).to receive(:primary_moab_location).and_return('storage_root2/sdr2objects')
-      end
-
-      it 'calls #ingest_bag and verify_version_storage on Moab::StorageObjectVersion' do
-        allow(LyberCore::Log).to receive(:debug).with('update-moab druid:bj102hs9687 starting')
-        expect(mock_storage_object_2).to receive(:ingest_bag).and_return(mock_new_version)
-        allow(verification_result).to receive(:verified).and_return(true)
-        expect(mock_new_version).to receive(:verify_version_storage).and_return(verification_result)
-        pres_update_moab.perform(full_druid)
       end
     end
   end

--- a/spec/preservation_ingest/validate_bag_spec.rb
+++ b/spec/preservation_ingest/validate_bag_spec.rb
@@ -11,10 +11,8 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::ValidateBag do
                     deposit_bag_pathname: deposit_bag_pathname,
                     current_version_id: 5)
   end
-  let(:mock_moabs) { [mock_moab] }
 
   before do
-    allow(Stanford::StorageServices).to receive(:search_storage_objects).with(druid).and_return(mock_moabs)
     allow(Stanford::StorageServices).to receive(:find_storage_object).and_return(mock_moab)
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

getting rid of unneeded multiple-moab code.

closes #401
closes #249 as a bonus

## How was this change tested? 🤨

rspec, ran pre-assembly image integration test (which checks that preservation works)

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


