### PR TITLE
remove unnec. delay just before update catalog

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,37 +1,33 @@
 redis:
-  url: 'localhost:6379/resque:test'
+  url: "localhost:6379/resque:test"
   timeout: 10 # seconds
 
-lybercore_log: 'log/lybercore.log'
+lybercore_log: "log/lybercore.log"
 
 # for workflows
 workflow:
-  url: 'https://workflows.example.org'
-  logfile: 'log/workflow_service.log'
-  shift_age: 'weekly'
+  url: "https://workflows.example.org"
+  logfile: "log/workflow_service.log"
+  shift_age: "weekly"
   timeout: 60 # seconds
 
 # where to find the deposit bag to be preserved
 transfer_object:
-  from_host: 'userid@dor-services-app'
-  from_dir: '/dor/export/'
+  from_host: "userid@dor-services-app"
+  from_dir: "/dor/export/"
 
 moab:
   # storage_roots:
   #   - '/services-disk/store1'
   #   - '/services-disk/store2'
-  storage_trunk: 'sdr2objects'
-  deposit_trunk: 'deposit'
-  path_method: 'druid_tree'
+  storage_trunk: "sdr2objects"
+  deposit_trunk: "deposit"
+  path_method: "druid_tree"
 
 preservation_catalog:
-  url: 'http://localhost:3000'
-  token: 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwcmVzZXJ2YXRpb25fcm9ib3RzIn0.cUW_P2o1eQFImKT4zVSJ9NrctVaE7h8TuBoSEpzPUVH0kQshz6S7XasotboxdmtEJj8kmCwXgr_ZZ6aUCTSCRg'
+  url: "http://localhost:3000"
+  token: "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwcmVzZXJ2YXRpb25fcm9ib3RzIn0.cUW_P2o1eQFImKT4zVSJ9NrctVaE7h8TuBoSEpzPUVH0kQshz6S7XasotboxdmtEJj8kmCwXgr_ZZ6aUCTSCRg"
 
 email_addresses:
-  discussion_list: 'user@discussion_list.org'
-  user_list: 'user@user_list.org'
-
-# we expect/hope that this will not stay around forever.  see usage for further explanation.
-hacks:
-  update_catalog_delay_seconds: 0.05 # the default value is artificially low to keep test suite fast -- should override to be many seconds in prod
+  discussion_list: "user@discussion_list.org"
+  user_list: "user@user_list.org"

--- a/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
@@ -28,34 +28,12 @@ module Robots
 
         def update_catalog
           remove_deposit_bag
-          wait_as_needed # give Ceph MDS some breathing room on the pres cat side, see comment on method
           with_retries(max_tries: 3, handler: handler("Updating preservation catalog for #{druid}"), rescue: Preservation::Client::Error) do
             Preservation::Client.update(druid: druid,
                                         version: moab_object.current_version_id,
                                         size: moab_object.size,
                                         storage_location: moab_object.storage_root)
           end
-        end
-
-        # sleep for a configured amount of time.
-        #
-        # BUT WHY? at present we're having an issue with Ceph backed preservation storage that plays out something like:
-        # * a preservation_robots worker finishes writing a new version of a Moab to its druid tree in the storage trunk, from a bag
-        #   left in the deposit trunk.
-        # * the preservation_robots worker signals preservation_catalog that it has finished updating the Moab (update_catalog, above).
-        # * preservation_catalog, running on a different VM from the preservation_robots worker, attempts to read the Moab contents.
-        #   * unfortunately, the Ceph MDS (Metadata Server) that responds to a preservation_catalog VM sometimes lags in learning that the
-        #     preservation_robots VM that wrote the Moab has given up the original write lock, and then preservation_catalog effectively
-        #     has trouble fully reading the contents of the new Moab version.  In our experience, a locked file will sometimes not become
-        #     available to pres cat until the MDS instance is restarted.  Though sometimes it becomes available on its own tens of seconds later.
-        #   * usually this happens when trying to read and zip the Moab version for cloud replication in a later async pres cat job.  but sometimes
-        #     it happens when the more cursory version check on the pres cat side of the update_catalog API call is executed.
-        #   * so there's an argument for putting the delay on the other side, in the API implementation.  but putting a multi-second delay
-        #     in something that's already an asynchronous job feels less icky than putting it in a REST method implementation, and there's
-        #     inescapable interplay here between pres robots and pres cat anyway.
-        # we hope to figure out a way to further tune our Ceph setup so that this delay is no longer needed.
-        def wait_as_needed
-          sleep(Settings.hacks.update_catalog_delay_seconds)
         end
 
         def remove_deposit_bag


### PR DESCRIPTION
## Why was this change made? 🤔

Part of #277

We have determined that the Ceph problems were solved by putting the machines on the same (mumble mumble network location) as Ceph storage, and this PR removes a hack that was added to try a delay before calling update_catalog.  The hack didn't work, and the shared_configs have the value set to 0.

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


