### PR TITLE
preservation-client is now version 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'dor-workflow-client', '~> 5.0'
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'lyber-core', '~> 6.1' # robot code
 gem 'moab-versioning', '~> 5.1' # work with Moab Objects
-gem 'preservation-client', '~> 4.0'
+gem 'preservation-client', '~> 5.0'
 gem 'redis', '~> 4.0' # redis 5.x has breaking changes with resque, see https://github.com/resque/resque/issues/1821
 gem 'resque'
 gem 'resque-pool'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    preservation-client (4.0.0)
+    preservation-client (5.0.0)
       activesupport (>= 4.2, < 8)
       faraday (~> 2.0)
       moab-versioning (~> 5.0)
@@ -227,7 +227,7 @@ DEPENDENCIES
   honeybadger
   lyber-core (~> 6.1)
   moab-versioning (~> 5.1)
-  preservation-client (~> 4.0)
+  preservation-client (~> 5.0)
   pry
   pry-byebug
   rake


### PR DESCRIPTION
## Why was this change made? 🤔

part of removing unused multiple moab code, sul-dlss/preservation_catalog/issues/1892

code for primary_moab_location was removed in PR #434;  preservation-client version 5.0.0 removes unused primary_moab_location

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


