### PR TITLE
Add feature flag for transfer via scp

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,7 @@ workflow:
 transfer_object:
   from_host: 'userid@dor-services-app'
   from_dir: '/dor/export/'
+  via_scp: false # keep feature flag off for now
 
 moab:
   # storage_roots:

--- a/spec/preservation_ingest/transfer_object_spec.rb
+++ b/spec/preservation_ingest/transfer_object_spec.rb
@@ -6,19 +6,22 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::TransferObject do
   let(:bare_druid) { 'jc837rq9922' }
   let(:druid) { "druid:#{bare_druid}" }
   let(:vm_file_path) do
-    from_dir = File.join(Settings.transfer_object.from_dir, bare_druid)
-    File.join(from_dir, described_class::VERSION_METADATA_PATH_SUFFIX)
+    File.join(Settings.transfer_object.from_dir, bare_druid, described_class::VERSION_METADATA_PATH_SUFFIX)
   end
   let(:deposit_dir_pathname) { Pathname(File.join(File.dirname(__FILE__), '..', 'fixtures', 'deposit', 'foo')) }
   let(:deposit_bag_pathname) { Pathname(File.join(deposit_dir_pathname, bare_druid)) }
   let(:xfer_obj) { described_class.new }
 
   before do
-    allow(Open3).to receive(:pipeline_r)
+    # NOTE: Both of these lines are here to cover the two methods currently used
+    #       to transfer bags. Once the SCP feature flag has been turned on for
+    #       good, or removed, we should remove one of these lines.
+    allow(Open3).to receive(:pipeline_r) # for transfer via tarpipe
+    allow(Open3).to receive(:popen2e) # for transfer via scp
   end
 
   after do
-    deposit_dir_pathname.rmtree if deposit_dir_pathname.exist?
+    FileUtils.rm_rf(deposit_dir_pathname)
   end
 
   context 'when versionMetadata.xml file does not exist' do
@@ -44,29 +47,29 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::TransferObject do
     end
 
     it 'ensures the deposit_dir_pathname is created if it does not exist' do
-      expect(deposit_dir_pathname.exist?).to be false
+      expect(deposit_dir_pathname).not_to exist
       xfer_obj.perform(druid)
-      expect(deposit_dir_pathname.exist?).to be true
+      expect(deposit_dir_pathname).to exist
     end
 
     it 'removes previous bag if it exists' do
       FileUtils.mkdir_p(deposit_bag_pathname)
       FileUtils.touch("#{deposit_bag_pathname}bagit_file.txt")
-      expect(deposit_bag_pathname.exist?).to be true
+      expect(deposit_bag_pathname).to exist
       xfer_obj.perform(druid)
-      expect(deposit_bag_pathname.exist?).to be false
+      expect(deposit_bag_pathname).not_to exist
     end
 
     it 'raises an ItemError if previous bag is not removed' do
       FileUtils.mkdir_p(deposit_bag_pathname)
       FileUtils.touch("#{deposit_bag_pathname}bagit_file.txt")
-      expect(deposit_bag_pathname.exist?).to be true
+      expect(deposit_bag_pathname).to exist
       allow(deposit_bag_pathname).to receive(:rmtree).and_raise(StandardError, 'rmtree failed')
       exp_msg = Regexp.escape("Error transferring bag (via userid@dor-services-app) for #{druid}: Failed preparation of deposit dir #{deposit_bag_pathname}")
       expect do
         xfer_obj.perform(druid)
       end.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
-      expect(deposit_bag_pathname.exist?).to be true
+      expect(deposit_bag_pathname).to exist
     end
   end
 
@@ -77,13 +80,35 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::TransferObject do
     before do
       allow(xfer_obj).to receive(:verify_version_metadata)
       allow(Stanford::StorageServices).to receive(:find_storage_object).and_return(mock_moab)
-      allow(Open3).to receive(:pipeline_r).and_raise(StandardError, 'tarpipe failed')
+      allow(Settings.transfer_object).to receive(:via_scp).and_return(scp_flag_enabled)
     end
 
-    it 'raises ItemError if there is a StandardError while executing the tarpipe command' do
-      expect do
-        xfer_obj.perform(druid)
-      end.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
+    context 'when transferring via tarpipe' do
+      let(:scp_flag_enabled) { false }
+
+      before do
+        allow(Open3).to receive(:pipeline_r).and_raise(StandardError, 'tarpipe failed')
+      end
+
+      it 'raises ItemError if there is a StandardError while executing the tarpipe command' do
+        expect do
+          xfer_obj.perform(druid)
+        end.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
+      end
+    end
+
+    context 'when transferring via scp' do
+      let(:scp_flag_enabled) { true }
+
+      before do
+        allow(Open3).to receive(:popen2e).and_raise(StandardError, 'tarpipe failed')
+      end
+
+      it 'raises ItemError if there is a StandardError while executing the tarpipe command' do
+        expect do
+          xfer_obj.perform(druid)
+        end.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
+      end
     end
   end
 
@@ -94,16 +119,35 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::TransferObject do
     before do
       allow(Robots::SdrRepo::PreservationIngest::Base).to receive(:execute_shell_command).and_return('yes')
       allow(Stanford::StorageServices).to receive(:find_storage_object).and_return(mock_moab)
+      allow(Settings.transfer_object).to receive(:via_scp).and_return(scp_flag_enabled)
     end
 
-    it 'transfers the object' do
-      expect(deposit_bag_pathname.exist?).to be false
-      xfer_obj.perform(druid)
-      expect(Open3).to have_received(:pipeline_r).with(
-        'ssh userid@dor-services-app "tar -C /dor/export/ --dereference -cf - jc837rq9922 "', /^tar -C/
-      )
-      expect(Robots::SdrRepo::PreservationIngest::Base).to have_received(:execute_shell_command).with(a_string_matching(cmd_regex))
-      expect(Stanford::StorageServices).to have_received(:find_storage_object)
+    context 'when transferring via tarpipe' do
+      let(:scp_flag_enabled) { false }
+
+      it 'transfers the object' do
+        expect(deposit_bag_pathname).not_to exist
+        xfer_obj.perform(druid)
+        expect(Open3).to have_received(:pipeline_r).with(
+          'ssh userid@dor-services-app "tar -C /dor/export/ --dereference -cf - jc837rq9922 "', /^tar -C/
+        )
+        expect(Robots::SdrRepo::PreservationIngest::Base).to have_received(:execute_shell_command).with(a_string_matching(cmd_regex))
+        expect(Stanford::StorageServices).to have_received(:find_storage_object)
+      end
+    end
+
+    context 'when transferring via scp' do
+      let(:scp_flag_enabled) { true }
+
+      it 'transfers the object' do
+        expect(deposit_bag_pathname).not_to exist
+        xfer_obj.perform(druid)
+        expect(Open3).to have_received(:popen2e).with(
+          %r{scp -pqr userid@dor-services-app:/dor/export/jc837rq9922 .+/spec/preservation_ingest/../fixtures/deposit/foo}
+        )
+        expect(Robots::SdrRepo::PreservationIngest::Base).to have_received(:execute_shell_command).with(a_string_matching(cmd_regex))
+        expect(Stanford::StorageServices).to have_received(:find_storage_object)
+      end
     end
   end
 end


### PR DESCRIPTION
# TODO

- [ ] Update DSA devopsdocs: https://github.com/sul-dlss/DevOpsDocs/blob/b786c266d181576f143bed68d97c3d71df5e9e10/projects/dor-services-app/operations-concerns.md#L59
- [ ] Update presbots devopsdocs: https://github.com/sul-dlss/DevOpsDocs/blob/aee3600c1aa3b43b96533d73205512178706ca7d/projects/preservation/preservation_robots/operations-concerns.md#L24
- [ ] Add test coverage

## Why was this change made? 🤔

Fixes #417

This commit adds a feature flag in front of a new feature: running bag transfers via scp instead of tarpipe. Once we are sure this change is harmless, and ideally offers some benefit in the form of hogging less CPU cycles, we can remove the feature flag and make it the default behavior.


## How was this change tested? 🤨

CI and will be tested in qa or stage
