### PR TITLE
Transfer bag by copying from filesystem

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,6 @@ workflow:
 
 # where to find the deposit bag to be preserved
 transfer_object:
-  from_host: 'userid@dor-services-app'
   from_dir: '/dor/export/'
 
 moab:

--- a/lib/robots/sdr_repo/preservation_ingest/transfer_object.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/transfer_object.rb
@@ -23,31 +23,27 @@ module Robots
 
         private
 
-        # Transfer and untar the object from the DOR export area to the SDR deposit area.
-        #   Note: POSIX tar has a limit of 100 chars in a filename
-        #     some implementations of gnu TAR work around this by adding a ././@LongLink file containing the full name
-        #     See: http://www.delorie.com/gnu/docs/tar/tar_114.html
-        #      http://stackoverflow.com/questions/2078778/what-exactly-is-the-gnu-tar-longlink-trick
-        #      http://www.gnu.org/software/tar/manual/html_section/Portability.html
-        #   Also, beware of incompatibilities between BSD tar and other TAR formats
-        #     regarding the handling of vendor extended attributes.
-        #     See: http://xorl.wordpress.com/2012/05/15/admin-mistakes-gnu-bsd-tar-and-posix-compatibility/
+        # Transfer the object from the DOR export area to the SDR deposit area.
         def transfer_object
           LyberCore::Log.debug("#{ROBOT_NAME} #{druid} starting")
           verify_version_metadata
           prepare_deposit_dir
           transfer_bag
         rescue StandardError => e
-          raise(ItemError, "Error transferring bag (via #{Settings&.transfer_object&.from_host}) for #{druid}: #{e.message}")
+          raise ItemError, "Error transferring bag (via #{Settings&.transfer_object&.from_dir}) for #{druid}: #{e.message}"
         end
 
         VERSION_METADATA_PATH_SUFFIX = '/data/metadata/versionMetadata.xml'
 
         # Check to see if the bag exists in the workspace directory before starting
         def verify_version_metadata
-          version_metadata_path = File.join(from_dir, bare_druid, VERSION_METADATA_PATH_SUFFIX)
-          cmd = "if ssh #{from_host} test -e #{version_metadata_path}; then echo yes; else echo no; fi"
-          raise(ItemError, "#{version_metadata_path} not found") if self.class.execute_shell_command(cmd) == 'no'
+          raise ItemError, "#{version_metadata_path} not found" unless version_metadata_path.exist?
+        end
+
+        def version_metadata_path
+          Pathname.new(
+            File.join(from_dir, bare_druid, VERSION_METADATA_PATH_SUFFIX)
+          )
         end
 
         def prepare_deposit_dir
@@ -58,43 +54,28 @@ module Robots
             deposit_dir.mkpath
           end
         rescue StandardError => e
-          raise(ItemError, "Failed preparation of deposit dir #{deposit_bag_pathname}: #{e.message}")
+          raise ItemError, "Failed preparation of deposit dir #{deposit_bag_pathname}: #{e.message}"
         end
 
         def deposit_dir
           deposit_bag_pathname.parent
         end
 
-        def from_host
-          Settings.transfer_object.from_host
-        end
-
         def from_dir
           Settings.transfer_object.from_dir
         end
 
-        # @see http://en.wikipedia.org/wiki/User:Chdev/tarpipe
-        # ssh user@remotehost "tar -cf - srcdir | tar -C destdir -xf -
-        # Note that symbolic links from /dor/export to /dor/workspace get
-        #  translated into real files by use of --dereference
-        # if command doesn't exit with 0, grabs stdout and stderr and puts them in ruby exception message
         def transfer_bag
-          ssh = "ssh #{from_host} \"tar -C #{from_dir} --dereference -cf - #{bare_druid} \""
-          untar = "tar -C #{deposit_dir} -xf -"
+          Open3.popen2e(transfer_command) do |_stdin, stdout_and_stderr, wait_thr|
+            output = stdout_and_stderr.read
+            status = wait_thr.value
 
-          # If you get an error here it might be a firewall issue between
-          # your preservation robots app and the configured
-          # Settings.transfer.from_host (dor-services-worker)
-          #
-          # This has also been known to fail when the ssh keys in
-          # ~/.ssh/known_hosts includes an invalid public key for the
-          # dor-services-worker, or if a user is required to authorize
-          # the addition of the new public key.
-
-          Open3.pipeline_r(ssh, untar) do |last_stdout, wait_threads|
-            stdout = last_stdout.read # Blocks until complete
-            raise "Transfering bag for #{druid} to preservation failed. STDOUT = #{stdout}" unless wait_threads.map(&:value).all?(&:success?)
+            raise "Transfering bag for #{druid} to preservation failed. STDOUT = #{output}" if status.nil? || !status.success?
           end
+        end
+
+        def transfer_command
+          "cp -rL #{File.join(from_dir, bare_druid)} #{deposit_dir}"
         end
 
         def bare_druid

--- a/spec/preservation_ingest/transfer_object_spec.rb
+++ b/spec/preservation_ingest/transfer_object_spec.rb
@@ -13,96 +13,92 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::TransferObject do
   let(:deposit_bag_pathname) { Pathname(File.join(deposit_dir_pathname, bare_druid)) }
   let(:xfer_obj) { described_class.new }
 
-  before do
-    allow(Open3).to receive(:pipeline_r)
-  end
-
   after do
     deposit_dir_pathname.rmtree if deposit_dir_pathname.exist?
   end
 
   context 'when versionMetadata.xml file does not exist' do
-    let(:cmd_regex) { Regexp.new(".*ssh #{Settings.transfer_object.from_host} test -e #{vm_file_path}.*") }
-
-    before do
-      allow(Robots::SdrRepo::PreservationIngest::Base).to receive(:execute_shell_command).and_return('no')
-    end
-
     it 'raises ItemError if versionMetadata.xml file for druid does not exist' do
-      expect { xfer_obj.perform(druid) }.to raise_error Robots::SdrRepo::PreservationIngest::ItemError,
-                                                        "Error transferring bag (via userid@dor-services-app) for #{druid}: #{vm_file_path} not found"
-      expect(Robots::SdrRepo::PreservationIngest::Base).to have_received(:execute_shell_command).with(a_string_matching(cmd_regex))
+      expect { xfer_obj.perform(druid) }.to raise_error(
+        Robots::SdrRepo::PreservationIngest::ItemError,
+        "Error transferring bag (via #{Settings.transfer_object.from_dir}) for #{druid}: #{vm_file_path} not found"
+      )
     end
   end
 
   describe 'creating a path for the deposit bag' do
+    let(:expected_message) do
+      Regexp.escape("Error transferring bag (via #{Settings.transfer_object.from_dir}) for #{druid}: " \
+                    "Failed preparation of deposit dir #{deposit_bag_pathname}")
+    end
     let(:mock_moab) { instance_double(Moab::StorageObject, deposit_bag_pathname: deposit_bag_pathname) }
 
     before do
       allow(xfer_obj).to receive(:verify_version_metadata)
+      allow(xfer_obj).to receive(:transfer_bag)
       allow(Stanford::StorageServices).to receive(:find_storage_object).and_return(mock_moab)
     end
 
     it 'ensures the deposit_dir_pathname is created if it does not exist' do
-      expect(deposit_dir_pathname.exist?).to be false
+      expect(deposit_dir_pathname).not_to exist
       xfer_obj.perform(druid)
-      expect(deposit_dir_pathname.exist?).to be true
+      expect(deposit_dir_pathname).to exist
     end
 
     it 'removes previous bag if it exists' do
       FileUtils.mkdir_p(deposit_bag_pathname)
       FileUtils.touch("#{deposit_bag_pathname}bagit_file.txt")
-      expect(deposit_bag_pathname.exist?).to be true
+      expect(deposit_bag_pathname).to exist
       xfer_obj.perform(druid)
-      expect(deposit_bag_pathname.exist?).to be false
+      expect(deposit_bag_pathname).not_to exist
     end
 
     it 'raises an ItemError if previous bag is not removed' do
       FileUtils.mkdir_p(deposit_bag_pathname)
       FileUtils.touch("#{deposit_bag_pathname}bagit_file.txt")
-      expect(deposit_bag_pathname.exist?).to be true
+      expect(deposit_bag_pathname).to exist
       allow(deposit_bag_pathname).to receive(:rmtree).and_raise(StandardError, 'rmtree failed')
-      exp_msg = Regexp.escape("Error transferring bag (via userid@dor-services-app) for #{druid}: Failed preparation of deposit dir #{deposit_bag_pathname}")
       expect do
         xfer_obj.perform(druid)
-      end.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
-      expect(deposit_bag_pathname.exist?).to be true
+      end.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(expected_message))
+      expect(deposit_bag_pathname).to exist
     end
   end
 
   context 'when there is an error executing the transfer' do
     let(:mock_moab) { instance_double(Moab::StorageObject, deposit_bag_pathname: deposit_bag_pathname) }
-    let(:exp_msg) { Regexp.escape("Error transferring bag (via userid@dor-services-app) for #{druid}: tarpipe failed") }
+    let(:expected_message) do
+      Regexp.escape("Error transferring bag (via #{Settings.transfer_object.from_dir}) for #{druid}: tarpipe failed")
+    end
 
     before do
       allow(xfer_obj).to receive(:verify_version_metadata)
       allow(Stanford::StorageServices).to receive(:find_storage_object).and_return(mock_moab)
-      allow(Open3).to receive(:pipeline_r).and_raise(StandardError, 'tarpipe failed')
+      allow(Open3).to receive(:popen2e).and_raise(StandardError, 'tarpipe failed')
     end
 
     it 'raises ItemError if there is a StandardError while executing the tarpipe command' do
       expect do
         xfer_obj.perform(druid)
-      end.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(exp_msg))
+      end.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, a_string_matching(expected_message))
     end
   end
 
   context 'when no errors are raised' do
     let(:mock_moab) { instance_double(Moab::StorageObject, deposit_bag_pathname: deposit_bag_pathname) }
-    let(:cmd_regex) { Regexp.new("if ssh #{Settings.transfer_object.from_host} test -e #{vm_file_path}.*") }
 
     before do
-      allow(Robots::SdrRepo::PreservationIngest::Base).to receive(:execute_shell_command).and_return('yes')
+      allow(xfer_obj).to receive(:verify_version_metadata)
       allow(Stanford::StorageServices).to receive(:find_storage_object).and_return(mock_moab)
+      allow(Open3).to receive(:popen2e)
     end
 
     it 'transfers the object' do
-      expect(deposit_bag_pathname.exist?).to be false
+      expect(deposit_bag_pathname).not_to exist
       xfer_obj.perform(druid)
-      expect(Open3).to have_received(:pipeline_r).with(
-        'ssh userid@dor-services-app "tar -C /dor/export/ --dereference -cf - jc837rq9922 "', /^tar -C/
+      expect(Open3).to have_received(:popen2e).with(
+        %r{cp -rL /dor/export/jc837rq9922 .+/spec/preservation_ingest/../fixtures/deposit/foo}
       )
-      expect(Robots::SdrRepo::PreservationIngest::Base).to have_received(:execute_shell_command).with(a_string_matching(cmd_regex))
       expect(Stanford::StorageServices).to have_received(:find_storage_object)
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #417

This commit changes how the transfer\_object step transfers bags from the `/dor/export` filesystem, moving from an SSH + tarpipe solution to a *NIX copy operation. This requires that all preservation_robots systems have the filesystem mounted, which is ongoing.

## How was this change tested? 🤨

CI and will be tested in QA
