### PR TITLE
UpdateCatalog: tolerate a missing deposit bag, but send an HB alert when that happens

### DIFF
--- a/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
@@ -50,7 +50,13 @@ module Robots
         # Ceph backed storage and our use of hardlinking (instead of e.g. copying) to get content from the
         # deposit bag to the new Moab version.  see https://github.com/sul-dlss/preservation_catalog/issues/1633
         def rm_deposit_bag_safely_for_ceph
-          deposit_bag_pathname.rmtree
+          if deposit_bag_pathname.exist?
+            deposit_bag_pathname.rmtree
+          else
+            Honeybadger.notify("Deposit bag was missing. This is unusual; it's likely that the workflow step ran once before, and " \
+                               "failed on the network call to preservation_catalog. Please confirm that all is well with #{druid}.")
+          end
+
           stat_moab_dir_contents
         end
 


### PR DESCRIPTION
## Why was this change made? 🤔

this is an unusual situation, and is usually harmless, but worth a quick look.

because this step happens after `validate-moab`, we should have reasonable confidence that the content has landed safely in preservation.

i'll file a ticket, but perhaps a less noisy and more effective action than sending an HB alert would be to request that pres cat run checksum validation on the druid.  then, if something is actually amiss, we'll still get an alert, and if not, there'll be no alert to disposition.  there's currently no pres cat API route for triggering checksum validation, but one could be added pretty easily (see `ObjectsController#validate_moab` -- would likely be very similar, just queuing a different job).

but putting this PR up for now, as-is, since it doesn't require the work of coordinating changes in two codebases, and is an improvement over the present state of things.


## How was this change tested? 🤨

CI, infra integration tests

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


