### PR TITLE
update-catalog: more helpful Honeybadger notification

### DIFF
--- a/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/update_catalog.rb
@@ -54,7 +54,8 @@ module Robots
             deposit_bag_pathname.rmtree
           else
             Honeybadger.notify("Deposit bag was missing. This is unusual; it's likely that the workflow step ran once before, and " \
-                               "failed on the network call to preservation_catalog. Please confirm that all is well with #{druid}.")
+                               "failed on the network call to preservation_catalog. Please confirm that #{druid} passes checksum " \
+                               'validation in preservation_catalog, and that its preserved version matches the Cocina in dor-services-app.')
           end
 
           stat_moab_dir_contents

--- a/spec/preservation_ingest/update_catalog_spec.rb
+++ b/spec/preservation_ingest/update_catalog_spec.rb
@@ -78,7 +78,8 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateCatalog do
         allow(Honeybadger).to receive(:notify)
         expect { update_catalog_obj.perform(druid) }.not_to raise_error
         hb_notify_msg = "Deposit bag was missing. This is unusual; it's likely that the workflow step ran once before, and " \
-                        "failed on the network call to preservation_catalog. Please confirm that all is well with #{druid}."
+                        "failed on the network call to preservation_catalog. Please confirm that #{druid} passes checksum " \
+                        'validation in preservation_catalog, and that its preserved version matches the Cocina in dor-services-app.'
         expect(Honeybadger).to have_received(:notify).with(hb_notify_msg)
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

@justinlittman correctly observes that the notification added in #466 could be more explicit/helpful.

## How was this change tested? 🤨

CI, since it only changes alert text

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


