### PR TITLE
pres cat API call improvements: tolerate 409 conflict in update-catalog step, have with_retries blocks catch only retriable connection errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'dor-workflow-client', '~> 5.0'
 gem 'honeybadger' # for error reporting / tracking / notifications
 gem 'lyber-core', '~> 6.1' # robot code
 gem 'moab-versioning', '~> 6.0' # work with Moab Objects
-gem 'preservation-client', '~> 5.0'
+gem 'preservation-client', '~> 6.0'
 gem 'redis', '~> 4.0' # redis 5.x has breaking changes with resque, see https://github.com/resque/resque/issues/1821
 gem 'resque'
 gem 'resque-pool'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
-    preservation-client (5.2.0)
+    preservation-client (6.1.0)
       activesupport (>= 4.2, < 8)
       faraday (~> 2.0)
       moab-versioning (>= 5.0.0, < 7)
@@ -231,7 +231,7 @@ DEPENDENCIES
   honeybadger
   lyber-core (~> 6.1)
   moab-versioning (~> 6.0)
-  preservation-client (~> 5.0)
+  preservation-client (~> 6.0)
   pry
   pry-byebug
   rake
@@ -251,4 +251,4 @@ DEPENDENCIES
   zeitwerk (~> 2.1)
 
 BUNDLED WITH
-   2.3.22
+   2.4.6

--- a/lib/robots/sdr_repo/preservation_ingest/validate_moab.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/validate_moab.rb
@@ -26,7 +26,7 @@ module Robots
         def validate_moab
           LyberCore::Log.debug("#{ROBOT_NAME} #{druid} starting")
           with_retries(max_tries: 3, handler: handler("Validating moab for #{druid}"),
-                       rescue: Preservation::Client::Error) do
+                       rescue: Preservation::Client::ConnectionFailedError) do
             Preservation::Client.objects.validate_moab(druid: druid)
           end
         end

--- a/spec/preservation_ingest/update_catalog_spec.rb
+++ b/spec/preservation_ingest/update_catalog_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateCatalog do
         stub_request(:post, 'http://localhost:3000/v1/catalog')
           .with(
             body: {
-              'checksums_validated' => 'true', 'druid' => 'druid:bj102hs9687',
-              'incoming_size' => '2342', 'incoming_version' => '1',
+              'checksums_validated' => true, 'druid' => 'druid:bj102hs9687',
+              'incoming_size' => 2342, 'incoming_version' => 1,
               'storage_location' => 'some/storage/location/from/endpoint/table'
             }
           )
@@ -94,8 +94,8 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateCatalog do
           stub_request(:post, 'http://localhost:3000/v1/catalog')
             .with(
               body: {
-                'checksums_validated' => 'true', 'druid' => 'bj102hs9687',
-                'incoming_size' => '2342', 'incoming_version' => '1',
+                'checksums_validated' => true, 'druid' => 'bj102hs9687',
+                'incoming_size' => 2342, 'incoming_version' => 1,
                 'storage_location' => 'some/storage/location/from/endpoint/table'
               }
             )
@@ -108,21 +108,29 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateCatalog do
         end
       end
 
-      context 'when it removes the deposit bag and when HTTP fails twice' do
+      context 'when it removes the deposit bag and when HTTP fails twice with a retriable error' do
         before do
+          2.times do
+            stub_request(:post, 'http://localhost:3000/v1/catalog')
+              .with(
+                body: {
+                  'checksums_validated' => true, 'druid' => 'bj102hs9687',
+                  'incoming_size' => 2342, 'incoming_version' => 1,
+                  'storage_location' => 'some/storage/location/from/endpoint/table'
+                }
+              )
+              .to_timeout
+          end
+
           stub_request(:post, 'http://localhost:3000/v1/catalog')
             .with(
               body: {
-                'checksums_validated' => 'true', 'druid' => 'bj102hs9687',
-                'incoming_size' => '2342', 'incoming_version' => '1',
+                'checksums_validated' => true, 'druid' => 'bj102hs9687',
+                'incoming_size' => 2342, 'incoming_version' => 1,
                 'storage_location' => 'some/storage/location/from/endpoint/table'
               }
             )
-            .to_return(
-              { status: 500, body: '', headers: {} },
-              { status: 500, body: '', headers: {} },
-              status: 200, body: '', headers: {}
-            )
+            .to_return(status: 200, body: '', headers: {})
         end
 
         it 'succeeds' do
@@ -132,21 +140,38 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateCatalog do
         end
       end
 
-      context 'when HTTP fails thrice' do
+      context 'when HTTP fails thrice with a retriable error' do
+        before do
+          3.times do
+            stub_request(:post, 'http://localhost:3000/v1/catalog')
+              .with(
+                body: {
+                  'checksums_validated' => true, 'druid' => 'bj102hs9687',
+                  'incoming_size' => 2342, 'incoming_version' => 1,
+                  'storage_location' => 'some/storage/location/from/endpoint/table'
+                }
+              )
+              .to_timeout
+          end
+        end
+
+        it 'removes the deposit bag and fails' do
+          expect { update_catalog_obj.perform(bare_druid) }.to raise_error(Preservation::Client::ConnectionFailedError)
+          expect(deposit_bag_pathname).to have_received(:rmtree)
+        end
+      end
+
+      context 'when HTTP fails with a non-retriable error' do
         before do
           stub_request(:post, 'http://localhost:3000/v1/catalog')
             .with(
               body: {
-                'checksums_validated' => 'true', 'druid' => 'bj102hs9687',
-                'incoming_size' => '2342', 'incoming_version' => '1',
+                'checksums_validated' => true, 'druid' => 'bj102hs9687',
+                'incoming_size' => 2342, 'incoming_version' => 1,
                 'storage_location' => 'some/storage/location/from/endpoint/table'
               }
             )
-            .to_return(
-              { status: 500, body: '', headers: {} },
-              { status: 500, body: '', headers: {} },
-              status: 500, body: '', headers: {}
-            )
+            .to_return(status: 500, body: '', headers: {})
         end
 
         it 'removes the deposit bag and fails' do
@@ -159,22 +184,49 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateCatalog do
     context 'when object already exists' do
       let(:version) { 3 }
 
-      before do
-        allow(deposit_bag_pathname).to receive(:rmtree)
-        stub_request(:patch, 'http://localhost:3000/v1/catalog/bj102hs9687')
-          .with(
-            body: {
-              'checksums_validated' => 'true', 'druid' => 'bj102hs9687',
-              'incoming_size' => '2342', 'incoming_version' => '3',
-              'storage_location' => 'some/storage/location/from/endpoint/table'
-            }
-          )
-          .to_return(status: 200, body: '', headers: {})
+      context 'when preservation_catalog is not yet aware of the new version' do
+        before do
+          allow(deposit_bag_pathname).to receive(:rmtree)
+          stub_request(:patch, 'http://localhost:3000/v1/catalog/bj102hs9687')
+            .with(
+              body: {
+                'checksums_validated' => true, 'druid' => 'bj102hs9687',
+                'incoming_size' => 2342, 'incoming_version' => 3,
+                'storage_location' => 'some/storage/location/from/endpoint/table'
+              }
+            )
+            .to_return(status: 200, body: '', headers: {})
+        end
+
+        it 'removes the deposit bag and PATCH to /v1/catalog/:druid' do
+          update_catalog_obj.perform(bare_druid)
+          expect(deposit_bag_pathname).to have_received(:rmtree)
+        end
       end
 
-      it 'removes the deposit bag and PATCH to /v1/catalog/:druid' do
-        update_catalog_obj.perform(bare_druid)
-        expect(deposit_bag_pathname).to have_received(:rmtree)
+      context 'when preservation_catalog is already aware of the new version' do
+        before do
+          allow(deposit_bag_pathname).to receive(:rmtree)
+          allow(Honeybadger).to receive(:notify)
+          stub_request(:patch, 'http://localhost:3000/v1/catalog/bj102hs9687')
+            .with(
+              body: {
+                'checksums_validated' => true, 'druid' => 'bj102hs9687',
+                'incoming_size' => 2342, 'incoming_version' => 3,
+                'storage_location' => 'some/storage/location/from/endpoint/table'
+              }
+            )
+            .to_return(status: 409, body: '', headers: {})
+        end
+
+        it 'removes the deposit bag, PATCH to /v1/catalog/:druid, and notifies due to the response' do
+          update_catalog_obj.perform(bare_druid)
+          expect(deposit_bag_pathname).to have_received(:rmtree)
+          hb_notify_msg = "preservation_catalog has already ingested this object version.  This is unusual, but it's likely that a " \
+                          'regularly scheduled preservation_catalog audit detected it after this workflow step was left in a failed state. ' \
+                          'Please confirm that the preserved version matches the Cocina in dor-services-app.'
+          expect(Honeybadger).to have_received(:notify).with(hb_notify_msg)
+        end
       end
     end
 
@@ -211,8 +263,8 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateCatalog do
         stub_request(:post, 'http://localhost:3000/v1/catalog')
           .with(
             body: {
-              'checksums_validated' => 'true', 'druid' => bare_druid,
-              'incoming_size' => '2342', 'incoming_version' => '1',
+              'checksums_validated' => true, 'druid' => bare_druid,
+              'incoming_size' => 2342, 'incoming_version' => 1,
               'storage_location' => 'some/storage/location/from/endpoint/table'
             }
           )


### PR DESCRIPTION
## Why was this change made? 🤔

adjust update-catalog tests to mock timeout responses where the intent is to test retriable errors, add test case for update-catalog HTTP 409 conflict handling

update to a version of preservation-client that has an exception type for 409 conflict

if/when https://github.com/sul-dlss/preservation-client/pull/97 is merged, i'll cut a release of pres client, update this to point to that release, squash the commits, and take out of draft.

i discovered the need for https://github.com/sul-dlss/preservation-client/pull/97 by running the unit tests after making the first commit in this PR (yay webmock and simulating HTTP responses instead of faking client behavior)

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


