### PR TITLE
explain why ValidateMoab#validate_moab makes preservation_catalog do the work

### DIFF
--- a/lib/robots/sdr_repo/preservation_ingest/validate_moab.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/validate_moab.rb
@@ -22,6 +22,20 @@ module Robots
 
         private
 
+        # @note Why call out to preservation_catalog to actually perform this WF step's checksum validation?
+        # We want the validation to run from another VM, and pres cat already handles replication and regularly
+        # scheduled fixity checking. Validating from a different VM catches a couple failure modes we've seen:
+        # 1) Temporary inability of the pres cat VMs' Ceph clients to read data recently written by
+        #    a preservation_robots Ceph client.
+        # 2) preservation_robots UpdateMoab gets control back as if the new Moab version has been fully written, when
+        #    in fact CephFS* may not have fully flushed its buffer to the underlying object store.  If the Ceph client loses
+        #    connectivity or the VM is rebooted before the buffer is flushed, unflushed buffered data will actually be
+        #    lost (though 0s may be written as placeholders, leading to files that seem complete at first glance).
+        # Running checksum validation on the Moab version after the file write operation has returned to preservation_robots,
+        # from a different VM's Ceph client, should catch either problem.
+        # * POSIX-compliant file system built on top of Ceph’s distributed object store, see Ceph docs
+        # ** A note in the preservation_catalog job that performs this work points to this explanation.  Please keep it up to
+        #    date if this architecture changes.
         def validate_moab
           logger.debug("#{ROBOT_NAME} #{druid} starting")
           with_retries(max_tries: 3, handler: handler("Validating moab for #{druid}"),


### PR DESCRIPTION
## Why was this change made? 🤔

confusion reduction

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


