### PR TITLE
Stop auto-requiring whenever gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'retries'
 gem 'sidekiq', '~> 7.0'
 gem 'slop'
 gem 'text-table' # to generate tables for StatsReporter
-gem 'whenever' # manage cron for robots and monitoring
+gem 'whenever', require: false # Work around https://github.com/javan/whenever/issues/831
 gem 'zeitwerk', '~> 2.1'
 
 source 'https://gems.contribsys.com/' do


### PR DESCRIPTION
## Why was this change made? 🤔

This commits works around a bug in the whenever gem that has begun crashing the Rails console when doing auto-
complete under Ruby 3.2: https://github.com/javan/whenever/issues/831

We shouldn't need the whenever gem required outside of the Capistrano deploy anyway.

## How was this change tested? 🤨

CI
