### PR TITLE
Enable new cops and fix linting errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -388,3 +388,20 @@ RSpec/Rails/MinitestAssertions: # new in 2.17
   Enabled: true
 RSpec/Rails/TravelAround: # new in 2.19
   Enabled: true
+
+Lint/MixedCaseRange: # new in 1.53
+  Enabled: true
+Lint/RedundantRegexpQuantifiers: # new in 1.53
+  Enabled: true
+Style/RedundantCurrentDirectoryInPath: # new in 1.53
+  Enabled: true
+Style/RedundantRegexpArgument: # new in 1.53
+  Enabled: true
+Style/ReturnNilInPredicateMethodDefinition: # new in 1.53
+  Enabled: true
+Style/YAMLFileRead: # new in 1.53
+  Enabled: true
+RSpec/ReceiveMessages: # new in 2.23
+  Enabled: true
+RSpec/Rails/NegationBeValid: # new in 2.23
+  Enabled: true

--- a/spec/preservation_ingest/update_moab_spec.rb
+++ b/spec/preservation_ingest/update_moab_spec.rb
@@ -28,10 +28,8 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::UpdateMoab do
         full_druid_vers = "#{full_druid}-v0003"
         error_message = "Failed verification for #{full_druid_vers}"
         allow(mock_storage_object).to receive(:ingest_bag).and_return(mock_new_version)
-        allow(verification_result).to receive(:verified).and_return(false)
+        allow(verification_result).to receive_messages(verified: false, to_json: 'some_json', entity: full_druid_vers)
         allow(mock_new_version).to receive(:verify_version_storage).and_return(verification_result)
-        allow(verification_result).to receive(:to_json).and_return('some_json')
-        allow(verification_result).to receive(:entity).and_return(full_druid_vers)
         expect { test_perform(pres_update_moab, full_druid) }.to raise_error(Robots::SdrRepo::PreservationIngest::ItemError, error_message)
         expect(mock_storage_object).to have_received(:ingest_bag)
         expect(mock_new_version).to have_received(:verify_version_storage)


### PR DESCRIPTION
## Why was this change made? 🤔

Enable new cops and autocorrect errors.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


