### PR TITLE
remove cruft from before ActiveJob backend was switched to sidekiq

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 require 'rake'
-require 'resque/pool/tasks'
 
 task :environment do
   require_relative 'config/boot'
 end
-
-task 'resque:setup' => :environment
 
 task default: :ci
 

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 server 'preservation-robots1-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor worker]
-# # robots2-prod is a warm standby - no resque-pool up but ready to deploy to if needed
+# # robots2-prod is a warm standby - no sidekiq up but ready to deploy to if needed
 # server 'preservation-robots2-prod.stanford.edu', user: 'pres', roles: %w[web app db monitor worker]
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 server 'preservation-robots1-qa.stanford.edu', user: 'pres', roles: %w[web app db worker]
-# robots2-qa is a warm standby - no resque-pool up but ready to deploy to if needed
+# robots2-qa is a warm standby - no sidekiq up but ready to deploy to if needed
 # server 'preservation-robots2-qa.stanford.edu', user: 'pres', roles: %w[web app db worker]
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 server 'preservation-robots1-stage.stanford.edu', user: 'pres', roles: %w[web app db worker]
-# robots2-stage is a warm standby - no resque-pool up but ready to deploy to if needed
+# robots2-stage is a warm standby - no sidekiq up but ready to deploy to if needed
 # server 'preservation-robots2-stage.stanford.edu', user: 'pres', roles: %w[web app db worker]
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,4 @@
-redis:
-  url: 'localhost:6379/resque:test'
-  timeout: 10 # seconds
+redis_url: redis://localhost:6379/
 
 lybercore_log: 'log/lybercore.log'
 

--- a/lib/activity_reporter.rb
+++ b/lib/activity_reporter.rb
@@ -26,7 +26,7 @@ class ActivityReporter
   def extract_druid(file, today, counter)
     File.readlines(file).each do |line|
       line =~ /#{today}/ || next
-      line =~ %r{/bundle/ruby|/usr/local/rvm|resque-signals/} && next
+      line =~ %r{/bundle/ruby|/usr/local/rvm/} && next
       druid = line.match(/Finished.*(#{DRUID_REGEXP})/) || next
       counter[druid] = 1
     end

--- a/lib/error_reporter.rb
+++ b/lib/error_reporter.rb
@@ -28,11 +28,7 @@ class ErrorReporter
           error_table.rows << [file, line, today]
           next
         end
-        if line.match?('WARN')
-          next if line.match?('resque-signals')
-
-          warning_table.rows << [file, line, today]
-        end
+        warning_table.rows << [file, line, today] if line.match?('WARN')
         stack.pop if stack.size > 2
       end
     end

--- a/spec/fixtures/log/sdr_preservationIngestWF_transfer-object.log
+++ b/spec/fixtures/log/sdr_preservationIngestWF_transfer-object.log
@@ -2,4 +2,3 @@ INFO [2017-04-27 11:07:36] (17545)  :: druid:db274ff1758 processing
 ERROR [2017-04-27 11:07:37] (17541)  :: Some Random Error
 /bundle/ruby
 /usr/local/rvm
-resque-signals/

--- a/spec/lib/activity_reporter_spec.rb
+++ b/spec/lib/activity_reporter_spec.rb
@@ -36,14 +36,14 @@ describe ActivityReporter do
           allow(Time).to receive(:now).and_return(dbl_date)
         end
 
-        context 'when file contains /bundle/ruby|/usr/local/rvm|resque-signals/' do
+        context 'when file contains /bundle/ruby|/usr/local/rvm/' do
           it 'prints out expected message' do
             output
             expect($stdout).to have_received(:puts).with("No activity 2017-04-27, DRUID count: 0\n")
           end
         end
 
-        context 'when file does not contain /bundle/ruby|/usr/local/rvm|resque-signals/' do
+        context 'when file does not contain /bundle/ruby|/usr/local/rvm/' do
           before do
             allow(activity_reporter).to receive(:default_log_files).and_return([happy_path])
           end


### PR DESCRIPTION
## Why was this change made? 🤔

when looking for sidekiq rake tasks (i didn't find any and ended up using the `service` command on the VM), i got an error because of `require 'resque/pool/tasks'` in `Rakefile`.  so i grepped for `resque` and got rid of what seemed like the remainder of the cruft from our switch to sidekiq.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do accessioning and/or create_preassembly_image_spec as it tests full preservation*** and/or test in stage environment, in addition to specs. ⚡


