### PR TITLE
Update ruby orb to version 4.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@4.2.0
+  ruby-rails: sul-dlss/ruby-rails@4.2.1
 workflows:
   build:
     jobs:


### PR DESCRIPTION
# Why was this change made? 🤔

Latest orb version is 4.2.1

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run at least one test from [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that verifies successful accessioning all the way through cloud replication, e.g. preassembly_reaccessioning_spec.rb,*** and/or test manually in stage environment, in addition to specs. ⚡


