### PR TITLE
Ruby 3.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@4.2.3
+  ruby-rails: sul-dlss/ruby-rails@4.3.0
 workflows:
   build:
     jobs:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -447,3 +447,52 @@ RSpec/RemoveConst: # new in 2.26
   Enabled: true
 RSpec/RepeatedSubjectCall: # new in 2.27
   Enabled: true
+
+Gemspec/AddRuntimeDependency: # new in 1.65
+  Enabled: true
+Lint/ArrayLiteralInRegexp: # new in 1.71
+  Enabled: true
+Lint/ConstantReassignment: # new in 1.70
+  Enabled: true
+Lint/DuplicateSetElement: # new in 1.67
+  Enabled: true
+Lint/HashNewWithKeywordArgumentsAsDefault: # new in 1.69
+  Enabled: true
+Lint/NumericOperationWithConstantResult: # new in 1.69
+  Enabled: true
+Lint/SharedMutableDefault: # new in 1.70
+  Enabled: true
+Lint/UnescapedBracketInRegexp: # new in 1.68
+  Enabled: true
+Lint/UselessDefined: # new in 1.69
+  Enabled: true
+Lint/UselessNumericOperation: # new in 1.66
+  Enabled: true
+Style/AmbiguousEndlessMethodDefinition: # new in 1.68
+  Enabled: true
+Style/BitwisePredicate: # new in 1.68
+  Enabled: true
+Style/CombinableDefined: # new in 1.68
+  Enabled: true
+Style/DigChain: # new in 1.69
+  Enabled: true
+Style/FileNull: # new in 1.69
+  Enabled: true
+Style/FileTouch: # new in 1.69
+  Enabled: true
+Style/HashSlice: # new in 1.71
+  Enabled: true
+Style/ItAssignment: # new in 1.70
+  Enabled: true
+Style/KeywordArgumentsMerging: # new in 1.68
+  Enabled: true
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+Style/RedundantInterpolationUnfreeze: # new in 1.66
+  Enabled: true
+Style/SafeNavigationChainLength: # new in 1.68
+  Enabled: true
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.4
   DisplayCopNames: true
   SuggestExtensions: false
   Exclude:

--- a/spec/lib/deposit_bag_validator_spec.rb
+++ b/spec/lib/deposit_bag_validator_spec.rb
@@ -131,7 +131,8 @@ RSpec.describe DepositBagValidator do
       dbv = described_class.new(storage_obj)
       code = described_class::PAYLOAD_SIZE_MISMATCH
       size_from_file = dbv.send(:bag_info_payload_size)
-      exp_msg = "Failed payload size verification. Expected: #{size_from_file}; found: {:bytes=>4300, :files=>4}"
+      expected_found_size = { bytes: 4300, files: 4 }
+      exp_msg = "Failed payload size verification. Expected: #{size_from_file}; found: #{expected_found_size}"
       expect(dbv.validation_errors).to eq [{ code => exp_msg }]
     end
 


### PR DESCRIPTION
# Why was this change made? 🤔

patch party to upgrade all deployed environments to ruby 3.4.1

# How was this change tested? 🤨

integration tests on stage and QA (preassembly_reaccessioning_spec, gis_accessioning_spec, preassembly_gis_raster_accessioning_spec, preassembly_gis_vector_accessioning_spec)

⚡ ⚠ If this change has cross service impact, ***run at least one test from [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that verifies successful accessioning all the way through cloud replication, e.g. preassembly_reaccessioning_spec.rb,*** and/or test manually in stage environment, in addition to specs. ⚡


