### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -4,7 +4,5 @@ server 'preservation-robots1-prod.stanford.edu', user: 'pres', roles: %w[web app
 # # robots2-prod is a warm standby - no sidekiq up but ready to deploy to if needed
 # server 'preservation-robots2-prod.stanford.edu', user: 'pres', roles: %w[web app db worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
-
 set :deploy_environment, 'prod'
 set :default_env, robot_environment: fetch(:deploy_environment)

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -4,7 +4,5 @@ server 'preservation-robots1-qa.stanford.edu', user: 'pres', roles: %w[web app d
 # robots2-qa is a warm standby - no sidekiq up but ready to deploy to if needed
 # server 'preservation-robots2-qa.stanford.edu', user: 'pres', roles: %w[web app db worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
-
 set :deploy_environment, 'qa'
 set :default_env, robot_environment: fetch(:deploy_environment)

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -4,7 +4,5 @@ server 'preservation-robots1-stage.stanford.edu', user: 'pres', roles: %w[web ap
 # robots2-stage is a warm standby - no sidekiq up but ready to deploy to if needed
 # server 'preservation-robots2-stage.stanford.edu', user: 'pres', roles: %w[web app db worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
-
 set :deploy_environment, 'stage'
 set :default_env, robot_environment: fetch(:deploy_environment)


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.