### PR TITLE
Temporarily pin lyber-core to < 9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,9 @@ gem 'rake'
 # Stanford DLSS gems
 gem 'dor-services-client'
 gem 'honeybadger' # for error reporting / tracking / notifications
-gem 'lyber-core'
+# Temporarily pinned lyber-core on 7/10/2026 since >v9.0 lybercore has version-aware breaking changes requiring updates
+# to all consumers simultaneously. See https://github.com/sul-dlss/dor-services-app/pull/6196
+gem 'lyber-core', '~> 8.0' # For robots
 gem 'moab-versioning' # work with Moab Objects
 gem 'preservation-client'
 gem 'retries'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     capistrano-one_time_key (0.2.0)
       capistrano (~> 3.0)
     capistrano-shared_configs (0.2.2)
-    cocina-models (0.126.0)
+    cocina-models (0.128.0)
       activesupport
       cocina_display
       deprecation
@@ -83,9 +83,9 @@ GEM
       capistrano-shared_configs
       ed25519
     docile (1.4.1)
-    dor-services-client (15.51.0)
+    dor-services-client (15.63.0)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.126.0)
+      cocina-models (~> 0.128.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -143,17 +143,17 @@ GEM
     iso8601 (0.13.0)
     janeway-jsonpath (1.0.0)
     json (2.20.0)
-    jsonschema_rs (0.46.10)
+    jsonschema_rs (0.47.0)
       bigdecimal (>= 3.1, < 5)
       rb_sys (~> 0.9.124)
-    jsonschema_rs (0.46.10-arm64-darwin)
+    jsonschema_rs (0.47.0-arm64-darwin)
       bigdecimal (>= 3.1, < 5)
-    jsonschema_rs (0.46.10-x86_64-linux)
+    jsonschema_rs (0.47.0-x86_64-linux)
       bigdecimal (>= 3.1, < 5)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
-    lyber-core (8.1.0)
+    lyber-core (8.2.0)
       activesupport
       config
       dor-services-client
@@ -317,7 +317,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-services-client
   honeybadger
-  lyber-core
+  lyber-core (~> 8.0)
   moab-versioning
   preservation-client
   pry


### PR DESCRIPTION
# Why was this change made? 🤔

To prevent breaking change in lyber-core being deployed until ready.
