### PR TITLE
Adds lane_id to validate moab robot.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       racc
     patience_diff (1.2.0)
       optimist (~> 3.0)
-    preservation-client (8.0.0)
+    preservation-client (8.1.0)
       activesupport (>= 4.2)
       faraday (~> 2.0)
       faraday-retry (~> 2.0)

--- a/lib/robots/sdr_repo/preservation_ingest/validate_moab.rb
+++ b/lib/robots/sdr_repo/preservation_ingest/validate_moab.rb
@@ -40,7 +40,7 @@ module Robots
           logger.debug("#{ROBOT_NAME} #{druid} starting")
           with_retries(max_tries: 3, handler: handler("Validating moab for #{druid}"),
                        rescue: Preservation::Client::ConnectionFailedError) do
-            Preservation::Client.objects.validate_moab(druid: druid)
+            Preservation::Client.objects.validate_moab(druid: druid, lane_id:)
           end
         end
       end

--- a/spec/robots/sdr_repo/preservation_ingest/validate_moab_spec.rb
+++ b/spec/robots/sdr_repo/preservation_ingest/validate_moab_spec.rb
@@ -4,10 +4,14 @@ RSpec.describe Robots::SdrRepo::PreservationIngest::ValidateMoab do
   subject(:this_robot) { described_class.new }
 
   let(:bare_druid) { 'bj102hs9687' }
-  let(:get_url) { "http://localhost:3000/v1/objects/#{bare_druid}/validate_moab" }
+  let(:get_url) { "http://localhost:3000/v1/objects/#{bare_druid}/validate_moab?lane-id=high" }
   let(:args) { { druid: bare_druid } }
 
   describe '#perform' do
+    before do
+      allow(this_robot).to receive(:lane_id).and_return('high') # rubocop:disable RSpec/SubjectStub
+    end
+
     context 'when the HTTP call is successful' do
       before do
         stub_request(:get, get_url).to_return(status: 200, body: 'ok', headers: {})


### PR DESCRIPTION
refs https://github.com/sul-dlss/preservation_catalog/issues/2653

# Why was this change made? 🤔



# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run at least one test from [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that verifies successful accessioning all the way through cloud replication, e.g. preassembly_reaccessioning_spec.rb,*** and/or test manually in stage environment, in addition to specs. ⚡


